### PR TITLE
Added admin checking

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -29,18 +29,46 @@ def get_remaining_runs(assignment, runs, now=None):
 
 
 def is_student(netid):
+	""""""
 	courses = db.get_courses_for_student(netid)
 	return bool(courses)
 
 
 def is_staff(netid):
+	"""
+	Check whether the given NetID is a staff member of at least 1 course.
+	:param netid: a user's NetID.
+	:return: a boolean value.
+	"""
 	courses = db.get_courses_for_staff(netid)
 	return bool(courses)
 
 
 def verify_student(netid, cid):
+	"""
+	Check whether the given NetID is a student in the given course.
+	:param netid: a user's NetID.
+	:param cid: a course ID.
+	:return: a boolean value.
+	"""
 	return netid in db.get_course(cid)["student_ids"]
 
 
+def verify_admin(netid, cid):
+	"""
+	Check whether the given NetID is a course admin in the given course.
+	:param netid: a user's NetID.
+	:param cid: a course ID.
+	:return: a boolean value.
+	"""
+	return netid in db.get_course(cid)["admin_ids"]
+
+
 def verify_staff(netid, cid):
+	"""
+	Check whether the given NetID is a staff member in the given course.
+	:param netid: a user's NetID.
+	:param cid: a course ID.
+	:return: a boolean value.
+	"""
 	return netid in db.get_course(cid)["staff_ids"]

--- a/src/routes_staff.py
+++ b/src/routes_staff.py
@@ -2,7 +2,7 @@ from flask import render_template, request, redirect, abort
 
 from src import db, util, auth, bw_api
 from src.config import TZ
-from src.common import verify_staff
+from src.common import verify_staff, verify_admin
 
 
 class StaffRoutes:
@@ -21,12 +21,13 @@ class StaffRoutes:
 
 			course = db.get_course(cid)
 			assignments = db.get_assignments_for_course(cid)
-			return render_template("staff/course.html", netid=netid, course=course, assignments=assignments, tzname=str(TZ), error=None)
+			is_admin = verify_admin(netid, cid)
+			return render_template("staff/course.html", netid=netid, course=course, assignments=assignments, tzname=str(TZ), is_admin=is_admin, error=None)
 
 		@app.route("/staff/course/<cid>/", methods=["POST"])
 		@auth.require_auth
 		def staff_attempt_add_assignment(netid, cid):
-			if not verify_staff(netid, cid):
+			if not verify_staff(netid, cid) or not verify_admin(netid, cid):
 				return abort(403)
 
 			def err(msg):

--- a/src/templates/staff/course.html
+++ b/src/templates/staff/course.html
@@ -36,58 +36,60 @@
             </table>
             <span class="text-secondary"> All times in {{ tzname }}</span>
         </div>
-        <div class="col-md-6 col-lg-4 col-xl-3">
-            <div class="card">
-                <div class="card-body">
-                    <h4 class="card-title">Add assignment</h4>
-                    <form action="." method="post">
-                        <div class="form-group">
-                            <label for="aid">Assignment ID</label>
-                            <input type="text" class="form-control" id="aid" name="aid">
-                        </div>
-                        <div class="form-group">
-                            <label for="max_runs">Max Runs</label>
-                            <input type="number" min="1" max="100" class="form-control" id="max_runs"
-                                   name="max_runs">
-                        </div>
-                        <div class="form-group">
-                            <label class="form-check-label">Quota Type</label><br>
-                            <div class="form-check form-check-inline">
-                                <input class="form-check-input" type="radio" name="quota" id="quota_daily"
-                                       value="daily" checked>
-                                <label class="form-check-label" for="quota_daily">
-                                    Daily
-                                </label>
-                            </div>
-                            <div class="form-check form-check-inline">
-                                <input class="form-check-input" type="radio" name="quota" id="quota_total"
-                                       value="total">
-                                <label class="form-check-label" for="quota_total">
-                                    Total
-                                </label>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label for="start">Start Date & Time</label> <span
-                                class="badge badge-secondary">{{ tzname }}</span>
-                            <input type="datetime-local" class="form-control" id="start" name="start">
-                        </div>
-                        <div class="form-group">
-                            <label for="start">End Date & Time</label> <span
-                                class="badge badge-secondary">{{ tzname }}</span>
-                            <input type="datetime-local" class="form-control" id="end" name="end">
-                        </div>
-                        {% if error %}
+        {% if is_admin %}
+            <div class="col-md-6 col-lg-4 col-xl-3">
+                <div class="card">
+                    <div class="card-body">
+                        <h4 class="card-title">Add assignment</h4>
+                        <form action="." method="post">
                             <div class="form-group">
-                            <span id="error" class="form-text text-danger">{{ error }}
-                            </span>
+                                <label for="aid">Assignment ID</label>
+                                <input type="text" class="form-control" id="aid" name="aid">
                             </div>
-                        {% endif %}
-                        <button type="submit" class="btn btn-primary">Save</button>
-                    </form>
+                            <div class="form-group">
+                                <label for="max_runs">Max Runs</label>
+                                <input type="number" min="1" max="100" class="form-control" id="max_runs"
+                                       name="max_runs">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-check-label">Quota Type</label><br>
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="radio" name="quota" id="quota_daily"
+                                           value="daily" checked>
+                                    <label class="form-check-label" for="quota_daily">
+                                        Daily
+                                    </label>
+                                </div>
+                                <div class="form-check form-check-inline">
+                                    <input class="form-check-input" type="radio" name="quota" id="quota_total"
+                                           value="total">
+                                    <label class="form-check-label" for="quota_total">
+                                        Total
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="form-group">
+                                <label for="start">Start Date & Time</label> <span
+                                    class="badge badge-secondary">{{ tzname }}</span>
+                                <input type="datetime-local" class="form-control" id="start" name="start">
+                            </div>
+                            <div class="form-group">
+                                <label for="start">End Date & Time</label> <span
+                                    class="badge badge-secondary">{{ tzname }}</span>
+                                <input type="datetime-local" class="form-control" id="end" name="end">
+                            </div>
+                            {% if error %}
+                                <div class="form-group">
+                                <span id="error" class="form-text text-danger">{{ error }}
+                                </span>
+                                </div>
+                            {% endif %}
+                            <button type="submit" class="btn btn-primary">Save</button>
+                        </form>
+                    </div>
                 </div>
             </div>
-        </div>
+        {% endif %}
     </div>
 </div>
 {% include 'footer.html' %}


### PR DESCRIPTION
Added course admin role. All functionality that needs to be limited to course admins should use `verify_admin` to enforce checks on all relevant endpoints (not just template rendering!).

Course configuration now requires a `admin_ids` field. The NetIDs in `admin_ids` should be a subset of the NetIDs in `staff_ids`.