### PR TITLE
[WIP] #17 Deploy Script

### DIFF
--- a/broadway-on-demand.service
+++ b/broadway-on-demand.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Gunicorn for Broadway on Demand
+After=network.target
+
+[Service]
+User=root
+Group=root
+WorkingDirectory=/srv/broadway-on-demand
+Environment=/srv/broadway-on-demand/src/venv/bin
+ExecStart=/srv/broadway-on-demand/src/venv/bin/gunicorn --workers 4 --bind 127.0.0.1:4000 src:app
+
+[Install]
+WantedBy=multi-user.target

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# NEED TO RUN AS ROOT
+
+INSTALL_DIR="/srv"
+VENV_NAME="venv"
+
+# Install python and related packages
+apt-get install python3 python3-venv
+
+# Default location for broadway-on-demand is /srv
+cp -r . $INSTALL_DIR/broadway-on-demand/
+cd $INSTALL_DIR/broadway-on-demand/
+
+# Setup venv
+cd src/
+python3 -m venv ./$VENV_NAME
+source ./$VENV_NAME/bin/activate
+
+# Install python dependencies
+python3 -m pip install -r requirements.txt
+python3 -m pip install gunicorn
+
+# Setup config file
+# CHANGE THIS
+# cp sample_config.py config.py
+
+# Setup systemd service
+cd ..
+cp broadway-on-demand.service /etc/systemd/system/
+systemctl enable broadway-on-demand
+systemctl start broadway-on-demand


### PR DESCRIPTION
#17 

Added install.sh which
1. Copies source files to /srv
2. Installs python and dependecies in a venv
3. Copies and sets up the systemd file and service
4. Launches the systemd service

This is slightly different from the existing deployment because this uses a virtualenv. Is that a good idea?

TODO: 
- Decide how to set up config and mongodb
- Create user?
- Some tests to ensure that service starts up correctly