### PR TITLE
Add feature to use unused autograder runs at midnight

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -137,3 +137,7 @@ def get_extensions(cid, aid, netid=None):
 
 def add_extension(cid, aid, netid, max_runs, start, end):
 	return mongo.db.extensions.insert_one({"course_id": cid, "assignment_id": aid, "netid": netid, "max_runs": max_runs, "remaining_runs": max_runs, "start": start, "end": end})
+
+
+def get_students_for_course(cid):
+	return get_course(cid)["student_ids"]


### PR DESCRIPTION
#19, #35 

Adds an endpoint under staff routes. This can be triggered by a cron script from the grader VM everyday, say, at 12:00:01 AM.

TODO: Needs testing. Need to verify that datetime usage is correct (do timezones mess with this somehow?)