### PR TITLE
Fix timestamp rounding.

### DIFF
--- a/src/routes_student.py
+++ b/src/routes_student.py
@@ -66,9 +66,9 @@ class StudentRoutes:
 					# find the extension that is closest to expiration
 					ext_to_use = min(active_extensions, key=lambda ext: ext["end"])
 
-			now = util.timestamp_round_up_minute(now)
+			now_rounded = util.timestamp_round_up_minute(now)
 
-			run_id = bw_api.start_grading_run(cid, aid, netid, now)
+			run_id = bw_api.start_grading_run(cid, aid, netid, now_rounded)
 			if run_id is None:
 				return err("Failed to start grading run. Please try again.")
 

--- a/src/template_filters.py
+++ b/src/template_filters.py
@@ -4,10 +4,15 @@ from jinja2 import Markup
 from pytz import utc
 
 from src.config import TZ
+from src.util import timestamp_round_up_minute
 
 
 class TemplateFilters:
 	def __init__(self, app):
+		@app.template_filter("round_timestamp")
+		def _filter_round_timestamp(timestamp):
+			return timestamp_round_up_minute(timestamp)
+
 		@app.template_filter("fmt_timestamp")
 		def _filter_fmt_timestamp(timestamp):
 			dt = datetime.utcfromtimestamp(timestamp).replace(tzinfo=utc).astimezone(TZ)

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -142,7 +142,7 @@
                     {% for run in student.runs %}
                         <tr>
                             <td>{{ run._id }}</td>
-                            <td>{{ run.timestamp|fmt_timestamp }}</td>
+                            <td>{{ run.timestamp | round_timestamp | fmt_timestamp }}</td>
                             <td>
                                 <button class="btn btn-secondary btn-sm" type="button" onclick="getRunStatus('{{ run._id }}')" id="status-{{ run._id }}">Check status</button>
                             </td>

--- a/src/templates/student/assignment.html
+++ b/src/templates/student/assignment.html
@@ -46,7 +46,7 @@
                 <tbody>
                 {% for run in runs %}
                     <tr>
-                        <td>{{ run.timestamp|fmt_timestamp_full }}</td>
+                        <td>{{ run.timestamp | round_timestamp | fmt_timestamp_full }}</td>
                         <td>
                             <button class="btn btn-secondary btn-sm" type="button" onclick="getRunStatus('{{ run._id }}')" id="status-{{ run._id }}">Check status</button>
                         </td>


### PR DESCRIPTION
We now store actual request timestamps but send and render rounded timestamps. This prevents requests made in the last minute of the day from being counted for the next day in computing remaining available runs.