### PR TITLE
Add files for systemctl deploy

### DIFF
--- a/on-demand.conf
+++ b/on-demand.conf
@@ -1,0 +1,6 @@
+location /on-demand {
+    include proxy_params;
+    proxy_pass http://unix:/srv/cs241/broadway-on-demand/broadway-on-demand.sock;
+    proxy_http_version 1.1;
+}
+

--- a/on-demand.service
+++ b/on-demand.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Gunicorn instance serving broadway-on-demand
+After=network.target
+
+[Service]
+User=andy2
+Group=www-data
+WorkingDirectory=/srv/cs241/broadway-on-demand
+Environment="PATH=/srv/cs241/broadway-on-demand/env/bin"
+ExecStart=/srv/cs241/broadway-on-demand/env/bin/gunicorn --workers 3 --bind unix:broadway-on-demand.sock -m 007 wsgi:app
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ requests==2.21.0
 urllib3==1.24.2
 werkzeug==0.15.3
 ansi2html==1.5.2
+gunicorn==20.0.4

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,4 @@
+from src.__init__ import app
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
Adds necessary files for deploying using gunicorn and nginx with systemctl for management, more robust than previous deployment method
Docs have been edited in anticipation