### PR TITLE
Assignment can be only visible from start date (and other UI changes)

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1,4 +1,5 @@
 from flask_pymongo import PyMongo, ASCENDING, DESCENDING
+from src import util
 
 mongo = PyMongo()
 
@@ -14,6 +15,13 @@ class Quota:
 	@classmethod
 	def is_valid(cls, quota):
 		return quota in [cls.DAILY, cls.TOTAL]
+
+
+# Assignment visibility to students
+class Visibility:
+	HIDDEN = "hidden"
+	VISIBLE = "visible"
+	VISIBLE_FROM_START = "visible_from_start" # visible from start date of the assignment
 
 
 def init(app):
@@ -54,7 +62,7 @@ def get_course(cid):
 
 
 def add_staff_to_course(cid, new_staff_id):
-	return mongo.db.courses.update({"_id": cid}, {"$addToSet": {"staff_ids": new_staff_id }})
+	return mongo.db.courses.update({"_id": cid}, {"$addToSet": {"staff_ids": new_staff_id}})
 
 
 def remove_staff_from_course(cid, staff_id):
@@ -67,7 +75,7 @@ def remove_staff_from_course(cid, staff_id):
 
 
 def add_student_to_course(cid, new_student_id):
-	return mongo.db.courses.update({"_id": cid}, {"$addToSet": {"student_ids": new_student_id }})
+	return mongo.db.courses.update({"_id": cid}, {"$addToSet": {"student_ids": new_student_id}})
 
 
 def remove_student_from_course(cid, student_id):
@@ -86,9 +94,28 @@ def overwrite_student_roster(cid, student_ids):
 	return mongo.db.courses.update({"_id": cid}, {"$set": {"student_ids": student_ids}})
 
 
-def get_assignments_for_course(cid, visible_only=True):
+def get_assignments_for_course(cid, visible_only=False):
 	if visible_only:
-		return list(mongo.db.assignments.find({"course_id": cid, "visibility": True}))
+		now = util.now_timestamp()
+		return list(mongo.db.assignments.find({
+			"course_id": cid,
+			"$or": [
+				# if visible from start date, and start date has past
+				{
+					"visibility": Visibility.VISIBLE_FROM_START,
+					"start": {
+						"$lte": now
+					}
+				},
+				{
+					"visibility": Visibility.VISIBLE
+				},
+				# TODO take this out after database shift
+				{
+					"visibility": True
+				}
+			]
+		}))
 	else:
 		return list(mongo.db.assignments.find({"course_id": cid}))
 

--- a/src/db.py
+++ b/src/db.py
@@ -21,7 +21,7 @@ class Quota:
 class Visibility:
 	HIDDEN = "hidden"
 	VISIBLE = "visible"
-	VISIBLE_FROM_START = "visible_from_start" # visible from start date of the assignment
+	VISIBLE_FROM_START = "visible_from_start"  # visible from start date of the assignment
 
 
 def init(app):
@@ -97,25 +97,21 @@ def overwrite_student_roster(cid, student_ids):
 def get_assignments_for_course(cid, visible_only=False):
 	if visible_only:
 		now = util.now_timestamp()
-		return list(mongo.db.assignments.find({
-			"course_id": cid,
-			"$or": [
-				# if visible from start date, and start date has past
-				{
-					"visibility": Visibility.VISIBLE_FROM_START,
-					"start": {
-						"$lte": now
-					}
-				},
-				{
-					"visibility": Visibility.VISIBLE
-				},
-				# TODO take this out after database shift
-				{
-					"visibility": True
-				}
-			]
-		}))
+		# if visible from start date, and start date has past
+		visible_from_start_date = {
+			"visibility": Visibility.VISIBLE_FROM_START,
+			"start": {"$lte": now}
+		}
+		# if always visible
+		visible_always = {
+			"visibility": Visibility.VISIBLE
+		}
+		# TODO take this out after database shift
+		visible_backward_compatible = {
+			"visibility": True
+		}
+		return list(mongo.db.assignments.find({"course_id": cid,"$or": [visible_from_start_date, visible_always,
+																		visible_backward_compatible]}))
 	else:
 		return list(mongo.db.assignments.find({"course_id": cid}))
 

--- a/src/routes_admin.py
+++ b/src/routes_admin.py
@@ -174,7 +174,7 @@ class AdminRoutes:
             except json.decoder.JSONDecodeError:
                 return util.error("Failed to decode config JSON")
 
-            visibility = request.form["visibility"] == "visible"
+            visibility = request.form["visibility"]
 
             db.add_assignment(cid, aid, max_runs, quota, start, end, visibility)
             return util.success("")
@@ -222,7 +222,7 @@ class AdminRoutes:
             except json.decoder.JSONDecodeError:
                 return util.error("Failed to decode config JSON")
 
-            visibility = request.form["visibility"] == "visible"
+            visibility = request.form["visibility"]
 
             if not db.update_assignment(cid, aid, max_runs, quota, start, end, visibility):
                 return util.error("Save failed or no changes were made.")

--- a/src/routes_staff.py
+++ b/src/routes_staff.py
@@ -35,10 +35,11 @@ class StaffRoutes:
                 return abort(HTTPStatus.FORBIDDEN)
 
             course = db.get_course(cid)
-            assignments = db.get_assignments_for_course(cid, visible_only=False)
+            assignments = db.get_assignments_for_course(cid)
             is_admin = verify_admin(netid, cid)
+            now = util.now_timestamp()
             return render_template("staff/course.html", netid=netid, course=course, assignments=assignments,
-                                   tzname=str(TZ), is_admin=is_admin, error=None)
+                                   tzname=str(TZ), is_admin=is_admin, now=now, visibility=db.Visibility, error=None)
 
         @blueprint.route("/staff/course/<cid>/<aid>/", methods=["GET"])
         @auth.require_auth
@@ -53,7 +54,7 @@ class StaffRoutes:
 
             return render_template("staff/assignment.html", netid=netid, course=course,
                                    assignment=assignment, student_runs=student_runs,
-                                   tzname=str(TZ), is_admin=is_admin)
+                                   tzname=str(TZ), is_admin=is_admin, visibility=db.Visibility)
 
         @blueprint.route("/staff/course/<cid>/<aid>/config", methods=["GET"])
         @auth.require_auth

--- a/src/routes_student.py
+++ b/src/routes_student.py
@@ -25,7 +25,11 @@ class StudentRoutes:
 				return abort(HTTPStatus.FORBIDDEN)
 
 			course = db.get_course(cid)
-			assignments = db.get_assignments_for_course(cid)
+			if verify_staff(netid, cid):
+				assignments = db.get_assignments_for_course(cid)
+			else:
+				assignments = db.get_assignments_for_course(cid, visible_only=True)
+
 			now = util.now_timestamp()
 
 			for assignment in assignments:
@@ -39,7 +43,8 @@ class StudentRoutes:
 
 				assignment.update({"total_available_runs": total_available_runs})
 
-			return render_template("student/course.html", netid=netid, course=course, assignments=assignments, tzname=str(TZ))
+			return render_template("student/course.html", netid=netid, course=course, assignments=assignments, now=now,
+								   tzname=str(TZ))
 
 		@blueprint.route("/student/course/<cid>/<aid>/", methods=["GET"])
 		@util.disable_in_maintenance_mode

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -66,8 +66,12 @@ table.table-fit {
     width: auto !important;
 }
 
-tr.assignment-no-runs {
+tr.assignment-no-runs, tr.assignment-past-deadline {
     background-color: rgb(247, 247, 247);
+}
+
+tr.assignment-no-runs a {
+    color: slategray;
 }
 
 .file-drop-box {

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -296,13 +296,18 @@
                                             </div>
                                             <div class="form-group">
                                                 <label class="form-check-label">Visibility</label><br>
+                                                <!-- TODO modify the if statement after database shift -->
                                                 <div class="form-check form-check-inline">
-                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-edit-assn-visibility" value="hidden" {% if not assignment.visibility %}checked{% endif %}>
-                                                    <label class="form-check-label" for="mdl-edit-assn-visibility">Not visible</label>
+                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-edit-assn-not-visible" value="{{ visibility.HIDDEN }}" {% if assignment.visibility == false or assignment.visibility == visibility.HIDDEN %}checked{% endif %}>
+                                                    <label class="form-check-label" for="mdl-edit-assn-not-visible">Not visible</label>
                                                 </div>
                                                 <div class="form-check form-check-inline">
-                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-edit-assn-visibility" value="visible" {% if assignment.visibility %}checked{% endif %}>
-                                                    <label class="form-check-label" for="mdl-edit-assn-visibility">Visible</label>
+                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-edit-assn-visible" value="{{ visibility.VISIBLE }}" {% if assignment.visibility == true or assignment.visibility == visibility.VISIBLE %}checked{% endif %}>
+                                                    <label class="form-check-label" for="mdl-edit-assn-visible">Visible</label>
+                                                </div>
+                                                <div class="form-check form-check-inline">
+                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-edit-assn-visible-from-start-date" value="{{ visibility.VISIBLE_FROM_START }}" {% if assignment.visibility == visibility.VISIBLE_FROM_START %}checked{% endif %}>
+                                                    <label class="form-check-label" for="mdl-edit-assn-visible-from-start-date">Visible from start date</label>
                                                 </div>
                                             </div>
                                             <div class="form-group">

--- a/src/templates/staff/course.html
+++ b/src/templates/staff/course.html
@@ -152,8 +152,8 @@
                 </tr>
                 </thead>
                 <tbody>
-                {% for assignment in assignments %}
-                    <tr>
+                {% for assignment in assignments | sort(attribute='start') | reverse %}
+                    <tr {% if assignment.end < now %} class="assignment-past-deadline" {% endif %}>
                         <td><a href="{{ url_for('.staff_get_assignment', cid=course._id, aid=assignment.assignment_id) }}">{{ assignment.assignment_id }}</a></td>
                         <td>{{ assignment.max_runs }} ({{ assignment.quota }})</td>
                         <td>{{ assignment.start|fmt_timestamp }}</td>
@@ -218,12 +218,16 @@
                                             <div class="form-group">
                                                 <label class="form-check-label">Visibility</label><br>
                                                 <div class="form-check form-check-inline">
-                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-add-assn-visibility" value="hidden" checked>
-                                                    <label class="form-check-label" for="mdl-add-assn-visibility">Not visible</label>
+                                                    <input class="form-check-input" type="radio" name=visibility" id="mdl-add-assn-not-visible" value="{{ visibility.HIDDEN }}">
+                                                    <label class="form-check-label" for="mdl-add-assn-not-visible">Not visible</label>
                                                 </div>
                                                 <div class="form-check form-check-inline">
-                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-add-assn-visibility" value="visible">
-                                                    <label class="form-check-label" for="mdl-add-assn-visibility">Visible</label>
+                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-add-assn-visible" value="{{ visibility.VISIBLE }}">
+                                                    <label class="form-check-label" for="mdl-add-assn-visible">Visible</label>
+                                                </div>
+                                                <div class="form-check form-check-inline">
+                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-add-assn-visible-from-start-date" value="{{ visibility.VISIBLE_FROM_START }}" checked>
+                                                    <label class="form-check-label" for="mdl-add-assn-visible-from-start-date">Visible from start date</label>
                                                 </div>
                                             </div>
                                             <div class="form-group">

--- a/src/templates/student/course.html
+++ b/src/templates/student/course.html
@@ -18,10 +18,16 @@
                 </tr>
                 </thead>
                 <tbody>
-                {% for assignment in assignments | reverse %}
-                <tr {% if assignment.total_available_runs <= 0 %} class="assignment-no-runs" {% endif %}>
+                {% for assignment in assignments | sort(attribute='start') | reverse %}
+                <tr {% if assignment.end < now %}
+                        {% if assignment.total_available_runs <= 0 %}
+                            class="assignment-no-runs"
+                        {% else %}
+                            class="assignment-past-deadline"
+                        {% endif %}
+                    {% endif %}>
                     <td>
-                        <a href="{{ url_for('.student_get_assignment', cid=course._id, aid=assignment.assignment_id) }}" {% if assignment.total_available_runs <= 0 %} style="color:slategray;" {% endif %}>{{assignment.assignment_id}}</a>
+                        <a href="{{ url_for('.student_get_assignment', cid=course._id, aid=assignment.assignment_id) }}">{{assignment.assignment_id}}</a>
                     </td>
                     <td>{{assignment.start|fmt_timestamp}}</td>
                     <td>{{assignment.end|fmt_timestamp}}</td>


### PR DESCRIPTION
## Changes
I made quite a few changes, but they are pretty small individually so I did them all at once.

- [biggest feature] visibility has new option: visible from start date. 
   - Benefit: staff can set up as many assignments as possible all at once, no need to toggle visibility throughout the semester.
   - Now this option is the default when creating new assignment
- staff can see "hidden" assignments on student view (#92)
- past assignments are grayed out for staff in both student/staff view (now the two list views look scarily similar but intuitive)
- students' assignments gray out no longer depends on number of available runs, but has to be past the deadline. 
    - If a student got extension, he will see gray background color + blue title
    - reason I changed this: when on the last day of assignment, student use up their last run, they will see the assignment grayed out even though the deadline hasn't passed. That feels weird to me.

## Testing
I tested the visibility from start feature, and backward compatibility. Student will only see "visible" assignments, or "visible from start" and "start date has past".

## TODOs
Since I moved the "visibility" attribute from boolean to string, we need to update our database on server to reflect this change. I added some backward compatible code that should be removed in the future.
- [ ] Update database
- [ ] Remove backward compatible code

## Screenshots
### Visible from start option
![image](https://user-images.githubusercontent.com/31719253/75948437-0f549580-5e69-11ea-882b-1a78c14fc206.png)
### Student Course View
![image](https://user-images.githubusercontent.com/31719253/75948822-14feab00-5e6a-11ea-9eeb-23af1795fe16.png)
Here vector and critical_concurrency are visible from start, eee is visible. You can see that both are visible to student.
### Staff (role) in Student Home View
![image](https://user-images.githubusercontent.com/31719253/75948860-35c70080-5e6a-11ea-9895-9232549f4166.png)
### Staff (role) in staff home view
Same as above
![image](https://user-images.githubusercontent.com/31719253/75948920-568f5600-5e6a-11ea-9651-5cea45fa8575.png)
