### PR TITLE
Bump werkzeug version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ pymongo==3.7.2
 pytz==2018.9
 requests==2.21.0
 urllib3==1.24.2
-werkzeug==0.15.3
+werkzeug==0.15.5
 ansi2html==1.5.2
 gunicorn==20.0.4


### PR DESCRIPTION
This fixes the python3.8 issues from earlier (tested locally on my machine).

https://stackoverflow.com/a/60140477