### PR TITLE
Remove DEV_MODE_LOGIN from being imported

### DIFF
--- a/src/ghe_api.py
+++ b/src/ghe_api.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from datetime import datetime as dt
 
 from config import (
-	GHE_OAUTH_URL, GHE_API_URL, GHE_CLIENT_ID, GHE_CLIENT_SECRET, DEV_MODE, DEV_MODE_LOGIN, TZ
+	GHE_OAUTH_URL, GHE_API_URL, GHE_CLIENT_ID, GHE_CLIENT_SECRET, DEV_MODE, TZ
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
`DEV_MODE_LOGIN` was deleted from sample_config.py in #83, but was still imported in ghe_api.py.

```
flask.cli.NoAppException: While importing "src", an ImportError was raised:
Traceback (most recent call last):
  File "/home/ezhang/CS241/broadway-on-demand/venv/lib/python3.8/site-packages/flask/cli.py", line 235, in locate_app
    __import__(module_name)
  File "/home/ezhang/CS241/broadway-on-demand/src/__init__.py", line 7, in <module>
    from src import db, bw_api, auth, ghe_api, util, common
  File "/home/ezhang/CS241/broadway-on-demand/src/ghe_api.py", line 6, in <module>
    from config import (
ImportError: cannot import name 'DEV_MODE_LOGIN' from 'config' (/home/ezhang/CS241/broadway-on-demand/config.py)
```