### PR TITLE
Fix static file path 404

### DIFF
--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -15,7 +15,7 @@
             integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
             crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
-    <link href="/static/styles.css" rel="stylesheet">
+    <link href="{{ url_for('.static_file', path='styles.css') }}" rel="stylesheet">
 
     <title>Log In | Broadway On Demand</title>
 </head>

--- a/src/templates/staff/course.html
+++ b/src/templates/staff/course.html
@@ -1,6 +1,6 @@
 {% set title = "%s (staff) (%s)" % (course.name, netid) %}
 {% include 'header.html' %}
-<script type="application/javascript" src="{{ url_for('static', filename='file_drag_drop_upload.js') }}"></script>
+<script type="application/javascript" src="{{ url_for('.static_file', path='file_drag_drop_upload.js') }}"></script>
 <script type="application/javascript">
     function addAssnErr(msg) {
         $('#mdl-add-assn-error').html(msg).show();

--- a/src/templates/staff/roster.html
+++ b/src/templates/staff/roster.html
@@ -100,7 +100,7 @@
     </div>
   </div>
 </div>
-<script src="{{ url_for('static', filename='file_drag_drop_upload.js') }}"></script>
+<script src="{{ url_for('.static_file', path='file_drag_drop_upload.js') }}"></script>
 <script>
   const staff_alert = "#add-staff-error";
   const student_alert = "#add-student-error";


### PR DESCRIPTION
Some static files are included using `/static/file_name` or `url_for('static', filename='file')`. These methods produce url without /on-demand/ prefix. Therefore some functionalities and styles are broken (e.g. login page and upload roster). This PR fixes this by using '.static_file' function we wrote. This might not be the ideal solution, but it works for now.

Screenshots of this error:
Login page style missing
![image](https://user-images.githubusercontent.com/31719253/91887011-cfbc0a00-ec4f-11ea-9c81-b773f3460cab.png)
File upload js not found:
![image](https://user-images.githubusercontent.com/31719253/91887051-e1051680-ec4f-11ea-8ab7-d7bbe7c36049.png)
