### PR TITLE
Avoid overwriting personal token when login

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -44,7 +44,7 @@ def set_user_access_token(netid, access_token):
 	:param netid: a user's NetID.
 	:param access_token: a GitHub Enterprise access token for the user.
 	"""
-	mongo.db.update_one({"_id": netid}, {"$set": {"access_token": access_token}}, upsert=True)
+	mongo.db.users.update_one({"_id": netid}, {"$set": {"access_token": access_token}}, upsert=True)
 
 def get_courses_for_student_or_staff(netid):
 	student_course = get_courses_for_student(netid)

--- a/src/db.py
+++ b/src/db.py
@@ -44,7 +44,7 @@ def set_user_access_token(netid, access_token):
 	:param netid: a user's NetID.
 	:param access_token: a GitHub Enterprise access token for the user.
 	"""
-	mongo.db.users.update({"_id": netid}, {"access_token": access_token}, upsert=True)
+	mongo.db.update_one({"_id": netid}, {"$set": {"access_token": access_token}}, upsert=True)
 
 def get_courses_for_student_or_staff(netid):
 	student_course = get_courses_for_student(netid)


### PR DESCRIPTION
Right now the personal token (used for roster sync authentication) will be overwritten when the user login through GHE, because `set_user_access_token` updates the whole document of user instead of only setting the access_token field. This PR changes this to a $set operation to avoid this.