### PR TITLE
Fix visibility toggle for new assignment

### DIFF
--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -147,6 +147,19 @@
         }
     }
 
+    function changeTextareaRow(id, json) {
+        // Change the size of config text area based on number of rows. This row number is an approximate
+        // because it doesn't consider wrapping.
+        let numRows = json.split("\n").length;
+        if (numRows <= 5) {
+            $(id).attr('rows', 5);
+        } else if (5 < numRows && numRows <= 20) {
+            $(id).attr('rows', numRows);
+        } else if (numRows > 20) {
+            $(id).attr('rows', 20);
+        }
+    }
+
     function loadOriginalConfig() {
         $('#mdl-edit-assn-config').val("Loading...").attr("disabled", "");
 
@@ -158,6 +171,7 @@
                 let json = JSON.stringify(result);
                 let old = normalizeJSON(json);
                 $('#mdl-edit-assn-config').val(old).data("old-config", old).removeAttr("disabled");
+                changeTextareaRow('#mdl-edit-assn-config', old);
             },
             error: function () {
                 $('#mdl-edit-assn-config')

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -141,7 +141,7 @@
 
     function normalizeJSON(json) {
         try {
-            return JSON.stringify(JSON.parse(json));
+            return JSON.stringify(JSON.parse(json), undefined, 2);
         } catch {
             return null;
         }

--- a/src/templates/staff/course.html
+++ b/src/templates/staff/course.html
@@ -218,7 +218,7 @@
                                             <div class="form-group">
                                                 <label class="form-check-label">Visibility</label><br>
                                                 <div class="form-check form-check-inline">
-                                                    <input class="form-check-input" type="radio" name=visibility" id="mdl-add-assn-not-visible" value="{{ visibility.HIDDEN }}">
+                                                    <input class="form-check-input" type="radio" name="visibility" id="mdl-add-assn-not-visible" value="{{ visibility.HIDDEN }}">
                                                     <label class="form-check-label" for="mdl-add-assn-not-visible">Not visible</label>
                                                 </div>
                                                 <div class="form-check form-check-inline">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31719253/92544662-11325380-f214-11ea-8c8b-905dea3d1856.png)
Before this fix, something like this happens when you try to select "not visible".

Turns out we are missing a double quote.
Now it's fixed in local testing
![image](https://user-images.githubusercontent.com/31719253/92544754-42ab1f00-f214-11ea-8164-db06609f1eea.png)
