### PR TITLE
Add delete assignment button

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -149,6 +149,12 @@ def update_assignment(cid, aid, max_runs, quota, start, end, visibility):
 	)
 	return res["n"] == 1 and 0 <= res["nModified"] <= 1
 
+def remove_assignment(cid, aid):
+	delete_filter = {"course_id": cid, "assignment_id": aid}
+	mongo.db.extensions.delete_many(delete_filter)
+	mongo.db.runs.delete_many(delete_filter)
+	res = mongo.db.assignments.delete_many(delete_filter)
+	return res.deleted_count == 1
 
 def get_assignment_runs_for_student(cid, aid, netid):
 	"""

--- a/src/routes_admin.py
+++ b/src/routes_admin.py
@@ -158,14 +158,14 @@ class AdminRoutes:
             if start >= end:
                 return util.error("Start must be before End.")
 
-            try:
-                config = json.loads(request.form["config"])
-                msg = bw_api.set_assignment_config(cid, aid, config)
+            # try:
+            #     config = json.loads(request.form["config"])
+            #     msg = bw_api.set_assignment_config(cid, aid, config)
 
-                if msg:
-                    return util.error(f"Failed to add assignment to Broadway: {msg}")
-            except json.decoder.JSONDecodeError:
-                return util.error("Failed to decode config JSON")
+            #     if msg:
+            #         return util.error(f"Failed to add assignment to Broadway: {msg}")
+            # except json.decoder.JSONDecodeError:
+            #     return util.error("Failed to decode config JSON")
 
             visibility = request.form["visibility"]
 
@@ -219,6 +219,14 @@ class AdminRoutes:
 
             if not db.update_assignment(cid, aid, max_runs, quota, start, end, visibility):
                 return util.error("Save failed or no changes were made.")
+            return util.success("")
+        
+        @blueprint.route("/staff/course/<cid>/<aid>/delete/", methods=["POST"])
+        @auth.require_auth
+        @auth.require_admin_status
+        def delete_assignment(netid, cid, aid):
+            if not db.remove_assignment(cid, aid):
+                return util.error("Assignment doesn't exist")
             return util.success("")
 
         @blueprint.route("/staff/course/<cid>/<aid>/extensions/", methods=["GET"])

--- a/src/routes_admin.py
+++ b/src/routes_admin.py
@@ -158,14 +158,14 @@ class AdminRoutes:
             if start >= end:
                 return util.error("Start must be before End.")
 
-            # try:
-            #     config = json.loads(request.form["config"])
-            #     msg = bw_api.set_assignment_config(cid, aid, config)
+            try:
+                config = json.loads(request.form["config"])
+                msg = bw_api.set_assignment_config(cid, aid, config)
 
-            #     if msg:
-            #         return util.error(f"Failed to add assignment to Broadway: {msg}")
-            # except json.decoder.JSONDecodeError:
-            #     return util.error("Failed to decode config JSON")
+                if msg:
+                    return util.error(f"Failed to add assignment to Broadway: {msg}")
+            except json.decoder.JSONDecodeError:
+                return util.error("Failed to decode config JSON")
 
             visibility = request.form["visibility"]
 

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -342,7 +342,7 @@
                             <div class="modal-dialog p-3" role="document" style="margin-top: 5rem;">
                                 <div class="modal-content">
                                     <div class="modal-header">
-                                        <h5 class="modal-title">Delete {{ course.name }}</h5>
+                                        <h5 class="modal-title">Delete {{ assignment.assignment_id }}</h5>
                                             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                                                 <span aria-hidden="true">&times;</span>
                                             </button>

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -338,8 +338,8 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="modal" tabindex="-1" role="dialog" id="delete-confirmation">
-                            <div class="modal-dialog" role="document">
+                        <div class="modal fade" tabindex="-1" role="dialog" id="delete-confirmation">
+                            <div class="modal-dialog p-3" role="document" style="margin-top: 5rem;">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <h5 class="modal-title">Delete {{ course.name }}</h5>

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -13,6 +13,23 @@
             '#mdl-edit-assn-save .loader', 
             '#mdl-edit-assn'
         );
+        // Deal with bootstrap 4 doesn't support double modaling
+        // https://stackoverflow.com/a/32712953/9059878
+        $('.modal').on("hidden.bs.modal", function (e) { //fire on closing modal box
+            if ($('.modal:visible').length) { // check whether parent modal is opend after child modal close
+                $('body').addClass('modal-open'); // if open mean length is 1 then add a bootstrap css class to body of the page
+            }
+        });
+    });
+
+    // Deal with bootstrap 4 doesn't support double modaling
+    // https://stackoverflow.com/questions/19305821/multiple-modals-overlay
+    $(document).on('show.bs.modal', '.modal', function () {
+        var zIndex = 1040 + (10 * $('.modal:visible').length);
+        $(this).css('z-index', zIndex);
+        setTimeout(function() {
+            $('.modal-backdrop').not('.modal-stack').css('z-index', zIndex - 1).addClass('modal-stack');
+        }, 0);
     });
 
     function addExtErr(msg) {
@@ -150,6 +167,30 @@
                 }
             })
     }
+
+    function deleteAssignment() {
+        $.ajax({
+            type: "POST",
+            url: "{{ url_for('.delete_assignment', cid=course._id, aid=assignment.assignment_id) }}",
+            dataType: "json",
+            beforeSend: () => {
+                $("#delete-assn-error").html("").fadeOut();
+                $("#delete-assn").prop('disabled', true);
+            },
+            success: () => {
+                location.replace("{{ url_for('.staff_get_course', cid=course._id) }}");
+            },
+            error: (xhr) => {
+                if (!xhr.responseText) {
+                    $("#delete-assn-error").html("Delete assignment failed. Please try again.").fadeIn();
+                } else {
+                    $("#delete-assn-error").html(xhr.responseText).fadeIn();
+                }
+            },
+        }).always(() => {
+            $("#delete-assn").prop('disabled', false);
+        });
+    }
 </script>
 <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
@@ -285,10 +326,34 @@
                                         </form>
                                     </div>
                                     <div class="modal-footer">
-                                        <button type="submit" form="edit-assn" class="btn btn-primary" id="mdl-edit-assn-save">
+                                        <button type="button" class="btn btn-outline-danger w-100" data-toggle="modal" data-target="#delete-confirmation">
+                                            <span class="fa fa-trash-alt" style="margin-right: 0.2em;"></span>
+                                            Delete
+                                        </button>
+                                        <button type="submit" form="edit-assn" class="btn btn-primary w-100" id="mdl-edit-assn-save">
                                             <span class="fa fa-cog loader" style="margin-right: 0.2em;"></span>
                                             Save
                                         </button>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal" tabindex="-1" role="dialog" id="delete-confirmation">
+                            <div class="modal-dialog" role="document">
+                                <div class="modal-content">
+                                    <div class="modal-header">
+                                        <h5 class="modal-title">Delete {{ course.name }}</h5>
+                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                    </div>
+                                    <div class="modal-body">
+                                        <p>Are you sure you want to delete <b>{{ assignment.assignment_id }}</b>?</p>
+                                        <span id="delete-assn-error" class="form-text text-danger"></span>
+                                    </div>
+                                    <div class="modal-footer">
+                                        <button type="button" class="btn btn-danger w-100" id="delete-assn" onclick="deleteAssignment()">Yes</button>
+                                        <button type="button" class="btn btn-secondary w-100" data-dismiss="modal">No</button>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Add delete assignment functionality, mostly for deleting test assignments. The related record (extension, runs) will also be deleted from the database along with the assignment itself.

## Edit assignment dialog
![image](https://user-images.githubusercontent.com/31719253/93036814-8a5feb00-f606-11ea-84ad-5a4a2ff8ba45.png)
## Confirmation modal
![image](https://user-images.githubusercontent.com/31719253/93037138-5f29cb80-f607-11ea-84f0-d0ff47219456.png)

## Error handling
![image](https://user-images.githubusercontent.com/31719253/93037521-40780480-f608-11ea-934f-088b54143526.png)

If the delete was successful, user will be redirected to "course" page.

Tested locally

