### PR TITLE
Fix bug for jQuery validation plugin

### DIFF
--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -1,7 +1,7 @@
 {% set title = "%s (staff) (%s)" % (course.name, netid) %}
 {% include 'header.html' %}
 {% include 'status.html' %}
-<script src="http://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
+<script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
 <script src="{{ url_for('.static_file', path='moment.min.js') }}"></script>
 <script src="{{ url_for('.static_file', path='modify_assignment.js') }}"></script>
 <script type="application/javascript">

--- a/src/templates/staff/course.html
+++ b/src/templates/staff/course.html
@@ -1,6 +1,6 @@
 {% set title = "%s (staff) (%s)" % (course.name, netid) %}
 {% include 'header.html' %}
-<script src="http://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
+<script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
 <script src="{{ url_for('.static_file', path='moment.min.js') }}"></script>
 <script src="{{ url_for('.static_file', path='modify_assignment.js') }}"></script>
 <script type="application/javascript">


### PR DESCRIPTION
I used http:// to include a script instead of https://, and chrome refused to load it ...
![image](https://user-images.githubusercontent.com/31719253/93112920-2973f980-f67e-11ea-80dc-d84d13146f5a.png)

I checked that the https:// file also exists. Will see if this works in prod...