### PR TITLE
Lowercase all NetIDs

### DIFF
--- a/src/ghe_api.py
+++ b/src/ghe_api.py
@@ -30,7 +30,7 @@ def get_access_token(code):
 def get_login(access_token):
 	try:
 		resp = requests.get("%s/user" % GHE_API_URL, params={"access_token": access_token})
-		return resp.json()["login"]
+		return resp.json()["login"].lower()
 	except requests.exceptions.RequestException:
 		return None
 	except KeyError:

--- a/src/routes_admin.py
+++ b/src/routes_admin.py
@@ -56,7 +56,7 @@ class AdminRoutes:
         @auth.require_auth
         @auth.require_admin_status
         def remove_course_staff(netid, cid):
-            staff_id = request.form.get('netid').lower()
+            staff_id = request.form.get('netid')
             result = db.remove_staff_from_course(cid, staff_id)
             if none_modified(result):
                 return util.error(f"'{staff_id}' is not a staff")

--- a/src/routes_admin.py
+++ b/src/routes_admin.py
@@ -42,7 +42,7 @@ class AdminRoutes:
         @auth.require_auth
         @auth.require_admin_status
         def add_course_staff(netid, cid):
-            new_staff_id = request.form.get('netid')
+            new_staff_id = request.form.get('netid').lower()
             if new_staff_id is None:
                 return util.error("Cannot find netid field")
             if not util.is_valid_netid(new_staff_id):
@@ -56,7 +56,7 @@ class AdminRoutes:
         @auth.require_auth
         @auth.require_admin_status
         def remove_course_staff(netid, cid):
-            staff_id = request.form.get('netid')
+            staff_id = request.form.get('netid').lower()
             result = db.remove_staff_from_course(cid, staff_id)
             if none_modified(result):
                 return util.error(f"'{staff_id}' is not a staff")
@@ -88,7 +88,7 @@ class AdminRoutes:
         @auth.require_auth
         @auth.require_admin_status
         def add_course_student(netid, cid):
-            new_student_id = request.form.get('netid')
+            new_student_id = request.form.get('netid').lower()
             if new_student_id is None:
                 return util.error("Cannot find netid field")
             if not util.is_valid_netid(new_student_id):
@@ -113,7 +113,7 @@ class AdminRoutes:
         @auth.require_admin_status
         def upload_roster_file(netid, cid):
             file_content = request.form.get('content')
-            netids = file_content.strip().split('\n')
+            netids = file_content.strip().lower().split('\n')
             for i, student_id in enumerate(netids):
                 if not util.is_valid_netid(student_id):
                     return util.error(f"Poorly formatted NetID on line {i + 1}: '{student_id}'")
@@ -249,7 +249,7 @@ class AdminRoutes:
             if util.check_missing_fields(request.form, "netids", "max_runs", "start", "end"):
                 return util.error("Missing fields. Please try again.")
 
-            student_netids = request.form["netids"].replace(" ", "").split(",")
+            student_netids = request.form["netids"].replace(" ", "").lower().split(",")
             for student_netid in student_netids:
                 if not util.valid_id(student_netid) or not verify_student(student_netid, cid):
                     return util.error(f"Invalid or non-existent student NetID: {student_netid}")

--- a/src/routes_api.py
+++ b/src/routes_api.py
@@ -9,7 +9,7 @@ class ApiRoutes:
         @auth.require_token_auth
         @auth.require_admin_status
         def admin_update_roster(netid, cid):
-            netids = request.form["roster"].split("\n")
+            netids = request.form["roster"].strip().lower().split("\n")
 
             for i, student_id in enumerate(netids):
                 if not util.is_valid_netid(student_id):


### PR DESCRIPTION
## Context
Some students' netids have different cases on roster vs on Github Enterprise. I have confirmed with a faculty that netids are case insensitive. So I'm changing all places where a netid (username) enters our system to be lowercased. This makes username comparison case insensitive.

## Changes
Lower case before
- GHE login 
- Add course staff
- Add student
- Web app upload roster file
- API upload roster file

All other cases get their netid from within the system. So they should be lowercased already.

## Testing
I tested logging in using GHE, but my netid is already lowercased so no difference there. Tested uploading roster with different cased netids, successfully lowered. Also tested add student and add staff with upper case. 