### PR TITLE
[easy] Make modal for logs wider

### DIFF
--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -3,6 +3,12 @@ body {
     font-family: 'Roboto', sans-serif;
 }
 
+@media (min-width: 576px) {
+    .modal-xl {
+        max-width: 80%;
+    }
+}
+
 i.fab, i.fas {
     margin-right: 0.3em;
 }

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -236,7 +236,7 @@
             <div class="text-secondary"> All times in {{ tzname }}</div>
         </div>
         <div class="modal fade" id="mdl-view-log" tabindex="-1" role="dialog" aria-labelledby="mdl-view-log-label" aria-hidden="true">
-            <div class="modal-dialog modal-lg" role="document">
+            <div class="modal-dialog modal-xl" role="document">
                 <div class="modal-content">
                     <div class="modal-header">
                         <h5 class="modal-title" id="mdl-view-log-label">View log: <span id="mdl-view-log-run-id"></span></h5>
@@ -409,7 +409,7 @@
                             <i class="fas fa-list"></i> View extensions
                         </button>
                         <div class="modal fade" id="mdl-view-exts" tabindex="-1" role="dialog" aria-labelledby="mdl-view-exts-label" aria-hidden="true">
-                            <div class="modal-dialog modal-lg" role="document">
+                            <div class="modal-dialog modal-xl" role="document">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <h5 class="modal-title" id="mdl-view-exts-label">View extensions</h5>

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -409,7 +409,7 @@
                             <i class="fas fa-list"></i> View extensions
                         </button>
                         <div class="modal fade" id="mdl-view-exts" tabindex="-1" role="dialog" aria-labelledby="mdl-view-exts-label" aria-hidden="true">
-                            <div class="modal-dialog modal-xl" role="document">
+                            <div class="modal-dialog modal-lg" role="document">
                                 <div class="modal-content">
                                     <div class="modal-header">
                                         <h5 class="modal-title" id="mdl-view-exts-label">View extensions</h5>


### PR DESCRIPTION
The log modal are not as large as it could be. Since most of the content are not wrapped, it's hard to see all of it.

# Before
![image](https://user-images.githubusercontent.com/31719253/98159962-15d95800-1ea3-11eb-8848-f0fb057312c2.png)


# After
Now it is 80% the screen width.
![image](https://user-images.githubusercontent.com/31719253/98159953-107c0d80-1ea3-11eb-835f-d61980308e8e.png)
