### PR TITLE
Prevent clicking action buttons when making request

### DIFF
--- a/src/static/modify_assignment.1.0.1.js
+++ b/src/static/modify_assignment.1.0.1.js
@@ -5,10 +5,11 @@
  * @param formName Name of form to validate
  * @param postUrl The url to send form data to
  * @param errorSelector Selector for element to display error
+ * @param saveBtn Selector for save button
  * @param saveBtnIcon The selector for icon on save button
  * @param modalSelector The selector for form modal
  */
-function modifyAssignment(formName, postUrl, errorSelector, saveBtnIcon, modalSelector) {
+function modifyAssignment(formName, postUrl, errorSelector, saveBtn, saveBtnIcon, modalSelector) {
     // custom validators
     $.validator.addMethod("check_id", function(value, element) {
         return this.optional(element) || /^[a-zA-Z0-9_\-]+$/.test(value);
@@ -72,11 +73,11 @@ function modifyAssignment(formName, postUrl, errorSelector, saveBtnIcon, modalSe
                 beforeSend: function () {
                     $(errorSelector).html('').fadeOut();
                     $(saveBtnIcon).addClass("fa-spin");
+                    $(saveBtn).prop('disabled', true);
                 },
                 success: function () {
                     $(modalSelector).modal('hide');
                     location.reload();
-                    $(saveBtnIcon).removeClass("fa-spin");
                 },
                 error: function (xhr) {
                     if (!xhr.responseText) {
@@ -84,9 +85,10 @@ function modifyAssignment(formName, postUrl, errorSelector, saveBtnIcon, modalSe
                     } else {
                         $(errorSelector).html(xhr.responseText).fadeIn();
                     }
-
-                    $(saveBtnIcon).removeClass("fa-spin");
                 }
+            }).always(() => {
+                $(saveBtnIcon).removeClass("fa-spin");
+                $(saveBtn).prop('disabled', false);
             });
         }
     });

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -61,6 +61,7 @@
             data: {netids: netids, max_runs: maxRuns, start: start, end: end},
             beforeSend: function () {
                 $('#mdl-add-ext-error').html('').hide();
+                $("#mdl-add-ext-save").prop('disabled', true);
             },
             success: function () {
                 $('#mdl-add-ext').modal('hide');
@@ -73,7 +74,9 @@
                     $('#mdl-add-ext-error').html(xhr.responseText).show();
                 }
             }
-        });
+        }).always(() => {
+            $("#mdl-add-ext-save").prop('disabled', false);
+        });;
     }
     function fmtTimestamp(timestamp) {
         return new Date(timestamp * 1000).toLocaleString('en-US', {timeZone: '{{ tzname }}'});

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -3,13 +3,14 @@
 {% include 'status.html' %}
 <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
 <script src="{{ url_for('.static_file', path='moment.min.js') }}"></script>
-<script src="{{ url_for('.static_file', path='modify_assignment.js') }}"></script>
+<script src="{{ url_for('.static_file', path='modify_assignment.1.0.1.js') }}"></script>
 <script type="application/javascript">
     $(() => { // on load
         modifyAssignment(
             "edit-assn", 
             `{{ url_for('.edit_assignment', cid=course._id, aid=assignment.assignment_id) }}`, 
             '#mdl-edit-assn-error', 
+            '#mdl-edit-assn-save',
             '#mdl-edit-assn-save .loader', 
             '#mdl-edit-assn'
         );

--- a/src/templates/staff/course.html
+++ b/src/templates/staff/course.html
@@ -2,13 +2,14 @@
 {% include 'header.html' %}
 <script src="https://ajax.aspnetcdn.com/ajax/jquery.validate/1.11.1/jquery.validate.min.js"></script>
 <script src="{{ url_for('.static_file', path='moment.min.js') }}"></script>
-<script src="{{ url_for('.static_file', path='modify_assignment.js') }}"></script>
+<script src="{{ url_for('.static_file', path='modify_assignment.1.0.1.js') }}"></script>
 <script type="application/javascript">
     $(() => { // on load
         modifyAssignment(
             "add-assn", 
             `{{ url_for('.add_assignment', cid=course._id) }}`, 
             '#mdl-add-assn-error', 
+            '#mdl-add-assn-save',
             '#mdl-add-assn-save .loader', 
             '#mdl-add-assn'
         );

--- a/src/templates/student/assignment.html
+++ b/src/templates/student/assignment.html
@@ -15,6 +15,7 @@
             },
             beforeSend: function () {
                 $('#grade-now-error').html('').hide();
+                $('#grade-now').prop('disabled', true);
             },
             success: function () {
                 location.reload();
@@ -26,6 +27,8 @@
                     $('#grade-now-error').html(xhr.responseText).show();
                 }
             }
+        }).always(() => {
+            $('#grade-now').prop('disabled', false);
         });
     }
 </script>
@@ -78,7 +81,7 @@
                     {% set has_commits = not not commit["sha"] %}
                     <form action="">
                         <input id="csrf_token" name="csrf_token" type="hidden" value="{{ csrf_token() }}">
-                        <button onclick="confirmGradeNow()" type="button" class="btn btn-primary" {% if not has_runs or not has_commits %}disabled{% endif %}>Grade Now</button>
+                        <button id="grade-now" onclick="confirmGradeNow()" type="button" class="btn btn-primary" {% if not has_runs or not has_commits %}disabled{% endif %}>Grade Now</button>
                     </form>
                     <p>
                         <strong>Start</strong> {{ assignment.start|fmt_timestamp }}

--- a/src/util.py
+++ b/src/util.py
@@ -1,4 +1,5 @@
 import uuid
+import time
 from datetime import datetime
 from functools import wraps
 from re import fullmatch
@@ -124,3 +125,14 @@ def is_valid_netid(netid):
 	:param netid: A netid string to be tested
 	"""
 	return fullmatch(r"[a-zA-Z0-9\-]+", netid) is not None
+
+def test_slow_respond(func):
+	"""
+	Decorator used to simulate slow server respond. Sleep 5 seconds before processing
+	the respond.
+	"""
+	@wraps(func)
+	def wrapper(*args, **kwargs):
+		time.sleep(3)
+		return func(*args, **kwargs)
+	return wrapper

--- a/src/util.py
+++ b/src/util.py
@@ -128,7 +128,7 @@ def is_valid_netid(netid):
 
 def test_slow_respond(func):
 	"""
-	Decorator used to simulate slow server respond. Sleep 5 seconds before processing
+	Decorator used to simulate slow server respond. Sleep a few seconds before processing
 	the respond.
 	"""
 	@wraps(func)


### PR DESCRIPTION
This was first brought to my attention by a 225 CA. She added an extension but it showed up twice. I think this is caused by she accidentally double tapped the save button. When fixing the add extension button, I realized we don't have double-clicking prevention for many other action buttons too. 

# Description
This PR disables the actions buttons after click, and re-enable them after server respond.

# Buttons modified
- Add/modify assignment
- Add extension
- Student "grade now" button

# Testing
![image](https://user-images.githubusercontent.com/31719253/98978579-d4b6f880-24df-11eb-8061-dc3d5ccc066f.png)

I also added a decorator function that slows down the server response by 3 second. It's useful when testing stuff like this.

# JS versioning
I added a version number for `modify_assignment.js` because otherwise the cached js code doesn't work with the html code (due to parameter change). Both must change at once. (if not, the whole save button was spinning...) Adding a version number forces the browser to reload the new js.