### PR TITLE
Migrate query request to Broadway endpoints to be direct

### DIFF
--- a/src/bw_api.py
+++ b/src/bw_api.py
@@ -40,31 +40,6 @@ def start_grading_run(cid, aid, netids, timestamp):
 	return run_id
 
 
-def get_grading_job_queue_position(cid, run_id):
-	"""
-	Get the queue position of a grading run.
-	:param cid: the course ID.
-	:param run_id: the run ID received when the run was started.
-	:return: the queue position as a string if successful, or None otherwise.
-	"""
-	try:
-		job_id = get_grading_run_job_id(cid, run_id)
-		if job_id == None:
-			return None
-		resp = requests.get(url=f"{BROADWAY_API_URL}/queue/{cid}/{job_id}/position", headers=build_header(cid))
-		queue_position = resp.json()["data"]["position"]
-		return str(queue_position)
-	except requests.exceptions.RequestException as e:
-		logging.error(f"get_grading_job_queue_position(cid={cid}, run_id={run_id}): {repr(e)}")
-		return None
-	except KeyError as e:
-		logging.error(f"get_grading_job_queue_position(cid={cid}, run_id={run_id}): {repr(e)}")
-		return None
-	except JSONDecodeError as e:
-		logging.error(f"get_grading_job_queue_position(cid={cid}, run_id={run_id}): {repr(e)}")
-		return None
-
-
 def get_assignment_config(cid, aid):
 	"""
 	Get run config for an assignment

--- a/src/bw_api.py
+++ b/src/bw_api.py
@@ -40,31 +40,6 @@ def start_grading_run(cid, aid, netids, timestamp):
 	return run_id
 
 
-@catch_request_errors
-def get_grading_run_state(cid, run_id):
-	"""
-	Get the state of a grading run. 
-	:param cid: the course ID.
-	:param run_id: the run ID received when the run was started.
-	:return: a state string if successful, or None otherwise.
-	"""
-	resp = requests.get(url=f"{BROADWAY_API_URL}/grading_run_status/{cid}/{run_id}", headers=build_header(cid))
-	return resp.json()["data"]["state"]
-
-
-@catch_request_errors
-def get_grading_job_status(cid, run_id):
-	"""
-	Get the status of a grading job within a grading run, assuming only 1 grading job in this run.
-	:param cid: the course ID.
-	:param run_id: the run ID received when the run was started.
-	:return: a status string if successful, or None otherwise.
-	"""
-	resp = requests.get(url=f"{BROADWAY_API_URL}/grading_run_status/{cid}/{run_id}", headers=build_header(cid))
-	student_jobs_dict = resp.json()["data"]["student_jobs_state"]
-	return list(student_jobs_dict.values())[0]
-
-
 def get_grading_job_queue_position(cid, run_id):
 	"""
 	Get the queue position of a grading run.

--- a/src/routes_staff.py
+++ b/src/routes_staff.py
@@ -87,17 +87,6 @@ class StaffRoutes:
 
             return jsonify(config)
 
-        @blueprint.route("/staff/course/<cid>/<aid>/<run_id>/status/", methods=["GET"])
-        @auth.require_auth
-        def staff_get_job_status(netid, cid, aid, run_id):
-            if not verify_staff(netid, cid):
-                return abort(HTTPStatus.FORBIDDEN)
-
-            status = bw_api.get_grading_job_status(cid, run_id)
-            if status:
-                return util.success(status, HTTPStatus.OK)
-            return util.error("")
-
         @blueprint.route("/staff/course/<cid>/<aid>/<run_id>/state/", methods=["GET"])
         @auth.require_auth
         def staff_get_run_state(netid, cid, aid, run_id):
@@ -127,6 +116,6 @@ class StaffRoutes:
                 return abort(HTTPStatus.FORBIDDEN)
 
             workers = bw_api.get_workers(cid)
-            if workers:
+            if workers is not None:
                 return util.success(jsonify(workers), HTTPStatus.OK)
             return util.error("")

--- a/src/routes_staff.py
+++ b/src/routes_staff.py
@@ -3,7 +3,7 @@ from http import HTTPStatus
 import logging
 from flask import render_template, abort, jsonify
 
-from config import TZ
+from config import TZ, BROADWAY_API_URL
 from src import db, util, auth, bw_api, sched_api
 from src.common import verify_staff, verify_admin
 
@@ -71,7 +71,8 @@ class StaffRoutes:
             return render_template("staff/assignment.html", netid=netid, course=course,
                                    assignment=assignment, student_runs=student_runs,
                                    scheduled_runs=scheduled_runs, sched_run_status=sched_api.ScheduledRunStatus,
-                                   tzname=str(TZ), is_admin=is_admin, visibility=db.Visibility)
+                                   tzname=str(TZ), is_admin=is_admin, visibility=db.Visibility,
+                                   broadway_api_url=BROADWAY_API_URL)
 
         @blueprint.route("/staff/course/<cid>/<aid>/config", methods=["GET"])
         @auth.require_auth

--- a/src/routes_staff.py
+++ b/src/routes_staff.py
@@ -87,17 +87,6 @@ class StaffRoutes:
 
             return jsonify(config)
 
-        @blueprint.route("/staff/course/<cid>/<aid>/<run_id>/state/", methods=["GET"])
-        @auth.require_auth
-        def staff_get_run_state(netid, cid, aid, run_id):
-            if not verify_staff(netid, cid):
-                return abort(HTTPStatus.FORBIDDEN)
-
-            state = bw_api.get_grading_run_state(cid, run_id)
-            if state:
-                return util.success(state, HTTPStatus.OK)
-            return util.error("")
-
         @blueprint.route("/staff/course/<cid>/<aid>/<run_id>/log/", methods=["GET"])
         @auth.require_auth
         def staff_get_run_log(netid, cid, aid, run_id):

--- a/src/routes_student.py
+++ b/src/routes_student.py
@@ -1,7 +1,7 @@
 from flask import render_template, request, abort
 from http import HTTPStatus
 
-from config import TZ
+from config import TZ, BROADWAY_API_URL
 from src import bw_api, auth, util, db
 from src.common import verify_student_or_staff, verify_staff, get_available_runs, get_active_extensions
 from src.ghe_api import get_latest_commit
@@ -68,7 +68,7 @@ class StudentRoutes:
 			if verify_staff(netid, cid):
 				num_available_runs = max(num_available_runs, 1)
 
-			return render_template("student/assignment.html", netid=netid, course=course, assignment=assignment, commit=commit, runs=runs, num_available_runs=num_available_runs, num_extension_runs=num_extension_runs, tzname=str(TZ))
+			return render_template("student/assignment.html", netid=netid, course=course, assignment=assignment, commit=commit, runs=runs, num_available_runs=num_available_runs, num_extension_runs=num_extension_runs, tzname=str(TZ), broadway_api_url=BROADWAY_API_URL)
 
 		@blueprint.route("/student/course/<cid>/<aid>/run/", methods=["POST"])
 		@util.disable_in_maintenance_mode

--- a/src/routes_student.py
+++ b/src/routes_student.py
@@ -104,15 +104,3 @@ class StudentRoutes:
 
 			db.add_grading_run(cid, aid, netid, now, run_id, extension_used=ext_to_use)
 			return util.success("")
-
-		@blueprint.route("/student/course/<cid>/<aid>/<run_id>/position/", methods=["GET"])
-		@util.disable_in_maintenance_mode
-		@auth.require_auth
-		def student_get_queue_position(netid, cid, aid, run_id):
-			if not verify_student_or_staff(netid, cid):
-				return abort(HTTPStatus.FORBIDDEN)
-
-			queue_position = bw_api.get_grading_job_queue_position(cid, run_id)
-			if queue_position:
-				return queue_position
-			return util.error("")

--- a/src/routes_student.py
+++ b/src/routes_student.py
@@ -105,18 +105,6 @@ class StudentRoutes:
 			db.add_grading_run(cid, aid, netid, now, run_id, extension_used=ext_to_use)
 			return util.success("")
 
-		@blueprint.route("/student/course/<cid>/<aid>/<run_id>/status/", methods=["GET"])
-		@util.disable_in_maintenance_mode
-		@auth.require_auth
-		def student_get_job_status(netid, cid, aid, run_id):
-			if not verify_student_or_staff(netid, cid):
-				return abort(HTTPStatus.FORBIDDEN)
-
-			status = bw_api.get_grading_job_status(cid, run_id)
-			if status:
-				return status
-			return util.error("")
-
 		@blueprint.route("/student/course/<cid>/<aid>/<run_id>/position/", methods=["GET"])
 		@util.disable_in_maintenance_mode
 		@auth.require_auth

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -15,7 +15,9 @@
             '#mdl-edit-assn-save .loader', 
             '#mdl-edit-assn'
         );
+        {% if is_admin %}
         initializeSchedRunForm(); // For add scheduled run and edit scheduled run form submission
+        {% endif %}
         // Deal with bootstrap 4 doesn't support double modaling
         // https://stackoverflow.com/a/32712953/9059878
         $('.modal').on("hidden.bs.modal", function (e) { //fire on closing modal box
@@ -90,7 +92,6 @@
             url: "{{ url_for('.staff_get_extensions', cid=course._id, aid=assignment.assignment_id) }}",
             dataType: "json",
             success: function (result) {
-                console.log(result);
                 let tbody = $('#mdl-view-exts-body');
                 tbody.empty();
                 if (result == undefined || result.length == 0) {

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -495,7 +495,9 @@
                         <td>
                             {% if run.status == sched_run_status.SCHEDULED %}<div class="text-info"><i class="fas fa-clock"></i>Scheduled</div>
                             {% elif run.status == sched_run_status.FAILED %}<div class="text-danger"><i class="fas fa-times-circle"></i>Failed</div>
-                            {% elif run.status == sched_run_status.RAN %}<button class="btn btn-success btn-sm" onclick="getRunState('{{ run.broadway_run_id }}')" id="status-{{ run.broadway_run_id }}"><i class="fas fa-check-circle"></i>check status</button>
+                            {% elif run.status == sched_run_status.RAN %}<button class="btn btn-success btn-sm"
+                                onclick="getRunState('{{ run.broadway_run_id }}', '{{ course._id }}', '{{ course.query_token }}')"
+                                id="status-{{ run.broadway_run_id }}"><i class="fas fa-check-circle"></i>check status</button>
                             {% endif %}
                         </td>
                         <td>

--- a/src/templates/staff/assignment.html
+++ b/src/templates/staff/assignment.html
@@ -457,7 +457,9 @@
                             <td>{{ run._id }}</td>
                             <td>{{ run.timestamp | round_timestamp | fmt_timestamp }}</td>
                             <td>
-                                <button class="btn btn-link btn-sm" type="button" data-toggle="tooltip" data-placement="top" title="Check status" onclick="getRunStatus('{{ run._id }}')" id="status-{{ run._id }}"><i class="fas fa-info-circle"></i>Status</button> 
+                                <button class="btn btn-link btn-sm" type="button" data-toggle="tooltip" data-placement="top" title="Check status"
+                                    onclick="getRunStatus('{{ run._id }}', '{{ course._id }}', '{{ course.query_token }}')" id="status-{{ run._id }}"><i
+                                        class="fas fa-info-circle"></i>Status</button>
                                 <button class="btn btn-link btn-sm" type="button" onclick="getRunLog('{{ run._id }}')" id="view-log-{{ run._id }}"><i class="fas fa-file-alt"></i>Log</button>
                             </td>
                         </tr>

--- a/src/templates/status.html
+++ b/src/templates/status.html
@@ -35,6 +35,7 @@
                 headers: buildHeader(queryToken),
                 success: function (result) {
                     let status = Object.values(result["data"]["student_jobs_state"])[0]
+                    let jobId = Object.keys(result["data"]["student_jobs_state"])[0]
                     var status_map = {
                         "scheduled": "btn-info",
                         "running": "btn-info",
@@ -46,7 +47,7 @@
                     for (var key in status_map) {
                         if (status.indexOf(key) != -1) {
                             if (key == "scheduled") {
-                                getQueuePosition(runId);
+                                getQueuePosition(runId, jobId, cid, queryToken);
                             } else {
                                 updateButtonContent(runId, status, status_map[key]);
                             }
@@ -60,13 +61,16 @@
             })
     }
 
-    function getQueuePosition(runId) {
+    function getQueuePosition(runId, jobId, cid, queryToken) {
         $.ajax(
             {
-                url: "./" + runId + "/position/",
+                type: "get",
+                url: `{{ broadway_api_url }}/queue/${cid}/${jobId}/position`,
+                headers: buildHeader(queryToken),
                 success: function (result) {
-                    let queuePositionString = "Your job is scheduled after " + result + " other jobs";
-                    if (result == "0") {
+                    let position = result["data"]["position"]
+                    let queuePositionString = "Your job is scheduled after " + position + " other jobs";
+                    if (position == "0") {
                         queuePositionString = "Your job is next";
                     }
                     updateButtonContent(runId, queuePositionString, "btn-info");
@@ -74,6 +78,7 @@
                 error: function () {
                     updateButtonContent(runId, "Your run is scheduled. Queue position unknown.", "btn-info");
                 }
-            })
+            }
+        )
     }
 </script>

--- a/src/templates/status.html
+++ b/src/templates/status.html
@@ -4,6 +4,10 @@
                              .attr("class", "btn btn-secondary btn-sm btn-text-break " + buttonType);
     }
 
+    function buildHeader(token) {
+        return { Authorization: `Bearer ${token}` };
+    }
+
     function getRunState(runId) {
         $.ajax({
             type: "get",
@@ -21,11 +25,14 @@
         })
     }
 
-    function getRunStatus(runId) {
+    function getRunStatus(runId, cid, queryToken) {
         $.ajax(
             {
-                url: "./" + runId + "/status/",
-                success: function (result) {
+                url: `{{ broadway_api_url }}/grading_run_status/${cid}/${runId}`,
+                headers: buildHeader(queryToken),
+                success: function (data) {
+                    let result = $.parseJSON(data);
+                    let status = Object.values(result["data"]["student_jobs_state"])[0]
                     var status_map = {
                         "scheduled": "btn-info",
                         "running": "btn-info",
@@ -35,11 +42,11 @@
                     };
 
                     for (var key in status_map) {
-                        if (result.indexOf(key) != -1) {
+                        if (status.indexOf(key) != -1) {
                             if (key == "scheduled") {
                                 getQueuePosition(runId);
                             } else {
-                                updateButtonContent(runId, result, status_map[key]);
+                                updateButtonContent(runId, status, status_map[key]);
                             }
                             break;
                         }

--- a/src/templates/status.html
+++ b/src/templates/status.html
@@ -28,10 +28,10 @@
     function getRunStatus(runId, cid, queryToken) {
         $.ajax(
             {
+                type: "get",
                 url: `{{ broadway_api_url }}/grading_run_status/${cid}/${runId}`,
                 headers: buildHeader(queryToken),
-                success: function (data) {
-                    let result = $.parseJSON(data);
+                success: function (result) {
                     let status = Object.values(result["data"]["student_jobs_state"])[0]
                     var status_map = {
                         "scheduled": "btn-info",

--- a/src/templates/status.html
+++ b/src/templates/status.html
@@ -8,15 +8,17 @@
         return { Authorization: `Bearer ${token}` };
     }
 
-    function getRunState(runId) {
+    function getRunState(runId, cid, queryToken) {
         $.ajax({
             type: "get",
-            url: `./${runId}/state/`,
-            success: (result) => {
-                if (result.indexOf("scheduled") != -1) {
-                    updateButtonContent(runId, result, "btn-info")
+            url: `{{ broadway_api_url }}/grading_run_status/${cid}/${runId}`,
+            headers: buildHeader(queryToken),
+                success: (result) => {
+                let status = result["data"]["state"]
+                if (status.indexOf("scheduled") != -1) {
+                    updateButtonContent(runId, status, "btn-info")
                 } else {
-                    updateButtonContent(runId, result, "btn-success")
+                    updateButtonContent(runId, status, "btn-success")
                 }
             },
             error: () => {

--- a/src/templates/student/assignment.html
+++ b/src/templates/student/assignment.html
@@ -55,7 +55,10 @@
                     <tr>
                         <td style="width: 50%">{{ run.timestamp | round_timestamp | fmt_timestamp_full }}</td>
                         <td style="width: 50%">
-                            <button class="btn btn-secondary btn-sm" type="button" onclick="getRunStatus('{{ run._id }}')" id="status-{{ run._id }}">Check status</button>
+                            <button class="btn btn-secondary btn-sm" type="button"
+                                onclick="getRunStatus('{{ run._id }}', '{{ course._id }}', '{{ course.query_token }}')"
+                                id="status-{{ run._id }}">Check
+                                status</button>
                         </td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
Before adding the integration for broadway job position SSE, I wanted to migrate our existing query requests.

### Before this migration
Any status query request (such as grading job status or queue position) must use on-demand server as a middle man to avoid leaking tokens.

- `on-demand client -> on-demand server -> broadway -> on-demand server -> on-demand client` 

This slows down performance by half and is especially slow for queue position query (which need to make 2 such trips).

### After this migration

Now the on-demand client can use query tokens to make direct requests

- `on-demand client -> broadway -> on-demand client` 

### TODO
- [x] Don't merge until [this broadway PR](https://github.com/illinois-cs241/broadway/pull/36) is deployed
- [x] Add `query_token` to each class in both on-demand and broadway before merging

### Testing
Tested with a local on-demand and broadway cluster.