### PR TITLE
Feedback on assignments page basic

### DIFF
--- a/src/routes_student.py
+++ b/src/routes_student.py
@@ -64,11 +64,11 @@ class StudentRoutes:
 
 			user = db.get_user(netid)
 			commit = get_latest_commit(netid, user["access_token"], course["github_org"])
-
+			feedback_url = f'https://github-dev.cs.illinois.edu/{course["github_org"]}/{netid}/tree/{course["feedback_branch_name"]}' if "feedback_branch_name" in course else None
 			if verify_staff(netid, cid):
 				num_available_runs = max(num_available_runs, 1)
 
-			return render_template("student/assignment.html", netid=netid, course=course, assignment=assignment, commit=commit, runs=runs, num_available_runs=num_available_runs, num_extension_runs=num_extension_runs, tzname=str(TZ), broadway_api_url=BROADWAY_API_URL)
+			return render_template("student/assignment.html", netid=netid, course=course, assignment=assignment, commit=commit, runs=runs, num_available_runs=num_available_runs, num_extension_runs=num_extension_runs, tzname=str(TZ), broadway_api_url=BROADWAY_API_URL, feedback_url=feedback_url)
 
 		@blueprint.route("/student/course/<cid>/<aid>/run/", methods=["POST"])
 		@util.disable_in_maintenance_mode

--- a/src/templates/student/assignment.html
+++ b/src/templates/student/assignment.html
@@ -93,7 +93,7 @@
                     <p>
                         <strong>Start</strong> {{ assignment.start|fmt_timestamp }}
                         <br><strong>End</strong> {{ assignment.end|fmt_timestamp }}
-                        <hr/>
+                        <hr>
                         {% if not commit["sha"] %}
                           <strong class="text-danger">Latest Commit</strong>
                           <br>{{ commit["message"] }}
@@ -103,7 +103,12 @@
                           <span title="{{ commit['message'] }}">{{ commit["message"] | truncate(50, killwords=True) }}</span>
                         {% endif %}
                         <div id="grade-now-error" class="text-danger"></div>
-
+                        <hr>
+                        <div id="feedback-link">
+                          <strong>Feedback URL</strong>
+                          <br>
+                          <a href="github.com" rel="link">github.com</a>
+                        </div>
                     </p>
                 </div>
             </div>

--- a/src/templates/student/assignment.html
+++ b/src/templates/student/assignment.html
@@ -103,12 +103,12 @@
                           <span title="{{ commit['message'] }}">{{ commit["message"] | truncate(50, killwords=True) }}</span>
                         {% endif %}
                         <div id="grade-now-error" class="text-danger"></div>
-                        <hr>
-                        <div id="feedback-link">
-                          <strong>Feedback URL</strong>
-                          <br>
-                          <a href="github.com" rel="link">github.com</a>
+			{% if runs and feedback_url %}
+			<hr/>
+			<div id="feedback-link">
+			  <a href="{{feedback_url}}" rel="link">Feedback branch</a>
                         </div>
+			{% endif %}
                     </p>
                 </div>
             </div>

--- a/src/templates/student/assignment.html
+++ b/src/templates/student/assignment.html
@@ -104,7 +104,7 @@
                         {% endif %}
                         <div id="grade-now-error" class="text-danger"></div>
 			{% if runs and feedback_url %}
-			<hr/>
+			<hr>
 			<div id="feedback-link">
 			  <a href="{{feedback_url}}" rel="link">Feedback branch</a>
                         </div>


### PR DESCRIPTION
Add link to feedback branch on the page with autograder runs

- Requires a field "feedback_branch_name" set in the course, e.g. ``_feedback`` for CS241.

![screenshot](https://user-images.githubusercontent.com/52917165/111889169-622fbb00-89a0-11eb-9fc7-55393be5423d.png)


Written by @astrosticks, @xucharles97, @willjguo, with help from @Xiangmingchen 