### PR TITLE
Bump jinja version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask-Session==0.3.1
 humanize==0.5.1
 idna==2.8
 itsdangerous==1.1.0
-Jinja2==2.10.1
+Jinja2==2.11.3
 MarkupSafe==1.1.0
 pymongo==3.7.2
 pytz==2018.9


### PR DESCRIPTION
Jinja has security issues in the previous version we were using. Bump and tested the new version locally. Everything seems to work.