### PR TITLE
Limit OAuth scope to none

### DIFF
--- a/sample_config.py
+++ b/sample_config.py
@@ -37,7 +37,7 @@ GHE_CLIENT_SECRET = "some_client_secret"
 # GitHub Enterprise OAuth base URL.
 GHE_OAUTH_URL = "https://some-github-enterprise-server.example/login/oauth"
 # GitHub Enterprise OAuth scopes to request from users (comma-separated string, no spaces).
-GHE_OAUTH_SCOPES = "repo"
+GHE_OAUTH_SCOPES = "none"
 GHE_LOGIN_URL = "%s/authorize?client_id=%s&scope=%s" % (GHE_OAUTH_URL, GHE_CLIENT_ID, GHE_OAUTH_SCOPES)
 
 # GitHub Enterprise API base URL.

--- a/src/ghe_api.py
+++ b/src/ghe_api.py
@@ -48,7 +48,7 @@ def get_latest_commit(netid, access_token, course):
 	commits_url += "?until=" + dt.now(tz=TZ).isoformat()
 	commits_url += "&sha=master"
 	try:
-                response = requests.get(commits_url, headers={"Authorization": "token {}".format(access_token)})
+		response = requests.get(commits_url, headers={"Authorization": "token {}".format(access_token)})
 	except requests.exceptions.RequestException as ex:
 		logger.error("Failed to fetch student commits\n{}".format(str(ex)))
 		return latest_commit

--- a/src/ghe_api.py
+++ b/src/ghe_api.py
@@ -29,7 +29,7 @@ def get_access_token(code):
 
 def get_login(access_token):
 	try:
-		resp = requests.get("%s/user" % GHE_API_URL, params={"access_token": access_token})
+		resp = requests.get("%s/user" % GHE_API_URL, headers={"Authorization": "token {}".format(access_token)})
 		return resp.json()["login"].lower()
 	except requests.exceptions.RequestException:
 		return None
@@ -48,7 +48,7 @@ def get_latest_commit(netid, access_token, course):
 	commits_url += "?until=" + dt.now(tz=TZ).isoformat()
 	commits_url += "&sha=master"
 	try:
-		response = requests.get(commits_url, params={"access_token": access_token})
+                response = requests.get(commits_url, headers={"Authorization": "token {}".format(access_token)})
 	except requests.exceptions.RequestException as ex:
 		logger.error("Failed to fetch student commits\n{}".format(str(ex)))
 		return latest_commit

--- a/src/routes_student.py
+++ b/src/routes_student.py
@@ -63,7 +63,8 @@ class StudentRoutes:
 			active_extensions, num_extension_runs = get_active_extensions(cid, aid, netid, now)
 
 			user = db.get_user(netid)
-			commit = get_latest_commit(netid, user["access_token"], course["github_org"])
+			token = course.get("github_token", "")
+			commit = get_latest_commit(netid, token, course["github_org"])
 			feedback_url = f'https://github-dev.cs.illinois.edu/{course["github_org"]}/{netid}/tree/{course["feedback_branch_name"]}' if "feedback_branch_name" in course else None
 			if verify_staff(netid, cid):
 				num_available_runs = max(num_available_runs, 1)


### PR DESCRIPTION
Changes:
- Updates format of authorization when sending requests to github's api
- Instead of using the student's own access token to find the latest commit in their repo, now each course is configured with a `GITHUB_TOKEN` in the database and that token is used to find the latest commit in their repo. This way we can set the OAuth scope to `none`, so we don't have access to any other of the student's private repos.

Tested these changes with local instance of on-demand.