### PR TITLE
Use Azure (Entra Id) auth instead of Google or deprecated GHE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # Broadway on Demand
 
+### Developer Setup (Docker Compose)
+
+- Copy `dev/dev_config.py` to repo root as `config.py`
+- Run `docker compose up`. Server runs at `localhost:3000` by default. This can be changed in the docker compose file.
+- To log in, navigate to <http://localhost:5000/on-demand/login/>. You can login as any user. In the test database there are three users:
+    - student (student of the test course)
+    - non-admin (a staff, but not an admin of the test course)
+    - admin (staff and admin of the test course)
+
 ### Developer setup
 
 - Install and start [MongoDB Server](https://www.mongodb.com/download-center/community). To ensure that MongoDB is running, run `mongo`.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 - Copy `dev/dev_config.py` to repo root as `config.py`
 - Run `docker compose up`. Server runs at `localhost:3000` by default. This can be changed in the docker compose file.
-- To log in, navigate to <http://localhost:5000/on-demand/login/>. You can login as any user. In the test database there are three users:
+- To log in, navigate to <http://localhost:3000/on-demand/login/>. You can login as any user. In the test database there are three users:
     - student (student of the test course)
     - non-admin (a staff, but not an admin of the test course)
     - admin (staff and admin of the test course)
 
-### Developer setup
+### Developer setup (Local)
 
 - Install and start [MongoDB Server](https://www.mongodb.com/download-center/community). To ensure that MongoDB is running, run `mongo`.
 - Clone the repository and `cd` into the repository root.

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,20 @@
+services:
+  web:
+    build:
+      context: .
+      args:
+        - DEP_DIR=/opt/broadway-on-demand
+        - CODE_DIR=/srv/broadway-on-demand
+      dockerfile: dev/web.Dockerfile
+    ports:
+      - "3000:5000"
+    volumes:
+      - ${PWD}/:/srv/broadway-on-demand
+  db:
+    build:
+      context: .
+      dockerfile: dev/db.Dockerfile
+    restart: always
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: dev123

--- a/compose.yml
+++ b/compose.yml
@@ -3,8 +3,8 @@ services:
     build:
       context: .
       args:
-        - DEP_DIR=/opt/broadway-on-demand
-        - CODE_DIR=/srv/broadway-on-demand
+        DEP_DIR: /opt/broadway-on-demand
+        CODE_DIR: /srv/broadway-on-demand
       dockerfile: dev/web.Dockerfile
     ports:
       - "3000:5000"
@@ -15,6 +15,3 @@ services:
       context: .
       dockerfile: dev/db.Dockerfile
     restart: always
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: dev123

--- a/dev/db.Dockerfile
+++ b/dev/db.Dockerfile
@@ -1,7 +1,10 @@
 FROM mongo:4.0
 
+ENV DEBIAN_FRONTEND=noninteractive
 ADD test_data.zip test_data.zip
-ADD load_db.sh load_db.sh
+ADD dev/load_db.sh load_db.sh
+RUN chmod +x ./load_db.sh
+RUN apt-get update && apt-get -y install unzip
 
 # Override the base ENTRYPOINT and CMD
-ENTRYPOINT load_db.sh
+ENTRYPOINT ./load_db.sh

--- a/dev/db.Dockerfile
+++ b/dev/db.Dockerfile
@@ -1,0 +1,7 @@
+FROM mongo:4.0
+
+ADD test_data.zip test_data.zip
+ADD load_db.sh load_db.sh
+
+# Override the base ENTRYPOINT and CMD
+ENTRYPOINT load_db.sh

--- a/dev/dev_config.py
+++ b/dev/dev_config.py
@@ -31,20 +31,12 @@ BROADWAY_API_URL = "http://some-broadway-api-server.example/api/v1"
 # API token used to authenticate /system/ routes.
 SYSTEM_API_TOKEN = "some_token"
 
-# GitHub Enterprise OAuth client ID and secret.
-GHE_CLIENT_ID = "some_client_id"
-GHE_CLIENT_SECRET = "some_client_secret"
-# GitHub Enterprise OAuth base URL.
-GHE_OAUTH_URL = "https://some-github-enterprise-server.example/login/oauth"
-# GitHub Enterprise OAuth scopes to request from users (comma-separated string, no spaces).
-GHE_OAUTH_SCOPES = "none"
-GHE_LOGIN_URL = "%s/authorize?client_id=%s&scope=%s" % (GHE_OAUTH_URL, GHE_CLIENT_ID, GHE_OAUTH_SCOPES)
-
-# GitHub Enterprise API base URL.
+# GitHub API base URL.
 GHE_API_URL = "https://api.github.com"
 
-# Google client ID for authentication (include the .apps.googleusercontent.com)
-GOOGLE_CLIENT_ID = "some_client_id.apps.googleusercontent.com"
-
-# Restricts Google Auth logins to emails with the given domain
-GOOGLE_AUTH_DOMAIN = "illinois.edu"
+# Microsoft Azure auth config
+AUTH_DOMAIN = "some auth domain like `illinois.edu`"
+MIP_SCOPES = ["email"]
+MIP_AUTHORITY = "some authority or `https://login.microsoftonline.com/common` for multi-tenant world-wide cloud"
+MIP_CLIENT_ID = "some_client_id"
+MIP_CLIENT_SECRET = "some_client_secret"

--- a/dev/dev_config.py
+++ b/dev/dev_config.py
@@ -1,0 +1,50 @@
+from pytz import timezone
+
+# When True, routes with the util.disable_in_maintenance_mode decorator will return a static page with the message below.
+MAINTENANCE_MODE = False
+# Message to show when in maintenance mode; appended to "Broadway on Demand is currently under maintenance."
+MAINTENANCE_MODE_MESSAGE = "Maintenance will conclude at __:__ on __/__."
+
+# When true, GitHub Enterprise login can be bypassed to log in as the username below.
+DEV_MODE = True
+
+# Server time zone, used for displaying times and specifying due date for Broadway API.
+TZ = timezone("America/Chicago")
+
+# The base URL used for all routes in the app.
+BASE_URL = "/on-demand"
+
+# Flask-Session configuration. See https://pythonhosted.org/Flask-Session/
+SESSION_TYPE = "mongodb"
+SESSION_MONGODB = "db:27017"
+SESSION_MONGODB_DB = "flask_session"
+
+# MongoDB URI for Broadway on Demand data.
+MONGO_URI = "mongodb://db:27017/broadway_on_demand"
+
+# Scheduler URI for scheduling runs
+SCHEDULER_URI = "http://localhost:3000/scheduler"
+
+# Broadway API configuration.
+BROADWAY_API_URL = "http://some-broadway-api-server.example/api/v1"
+
+# API token used to authenticate /system/ routes.
+SYSTEM_API_TOKEN = "some_token"
+
+# GitHub Enterprise OAuth client ID and secret.
+GHE_CLIENT_ID = "some_client_id"
+GHE_CLIENT_SECRET = "some_client_secret"
+# GitHub Enterprise OAuth base URL.
+GHE_OAUTH_URL = "https://some-github-enterprise-server.example/login/oauth"
+# GitHub Enterprise OAuth scopes to request from users (comma-separated string, no spaces).
+GHE_OAUTH_SCOPES = "none"
+GHE_LOGIN_URL = "%s/authorize?client_id=%s&scope=%s" % (GHE_OAUTH_URL, GHE_CLIENT_ID, GHE_OAUTH_SCOPES)
+
+# GitHub Enterprise API base URL.
+GHE_API_URL = "https://api.github.com"
+
+# Google client ID for authentication (include the .apps.googleusercontent.com)
+GOOGLE_CLIENT_ID = "some_client_id.apps.googleusercontent.com"
+
+# Restricts Google Auth logins to emails with the given domain
+GOOGLE_AUTH_DOMAIN = "illinois.edu"

--- a/dev/load_db.sh
+++ b/dev/load_db.sh
@@ -1,0 +1,6 @@
+docker-entrypoint.sh mongod &
+
+# Give db some time to start
+sleep 3
+
+unzip test_data.zip && mongorestore test_data && rm -rf test_data

--- a/dev/load_db.sh
+++ b/dev/load_db.sh
@@ -4,3 +4,5 @@ docker-entrypoint.sh mongod &
 sleep 3
 
 unzip test_data.zip && mongorestore test_data && rm -rf test_data
+
+wait

--- a/dev/web.Dockerfile
+++ b/dev/web.Dockerfile
@@ -9,7 +9,7 @@ RUN echo $DEP_DIR
 RUN echo $CODE_DIR
 
 WORKDIR ${DEP_DIR}
-RUN apk add --no-cache gcc musl-dev linux-headers
+RUN apk add --no-cache gcc musl-dev linux-headers libffi-dev
 COPY requirements.txt requirements.txt
 RUN python3 -m venv ./env
 RUN source ./env/bin/activate && pip install -r requirements.txt

--- a/dev/web.Dockerfile
+++ b/dev/web.Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.7-alpine
+
+# Change to dependency directory
+WORKDIR ${DEP_DIR}
+RUN apk add --no-cache gcc musl-dev linux-headers
+COPY requirements.txt requirements.txt
+RUN python3 -m virtualenv ./env && source ./env/bin/activate
+RUN pip install -r requirements.txt
+ENV PATH=${DEP_DIR}/env/bin
+
+# Change to the code directory for development
+WORKDIR ${CODE_DIR}
+EXPOSE 5000
+ENV FLASK_APP=src
+ENV FLASK_ENV=development
+ENV FLASK_RUN_HOST=0.0.0.0
+ENV FLASK_DEBUG="true"
+CMD ["${DEP_DIR}/env/bin/flask", "run"]

--- a/dev/web.Dockerfile
+++ b/dev/web.Dockerfile
@@ -1,12 +1,18 @@
 FROM python:3.7-alpine
 
+ARG DEP_DIR /opt/broadway-on-demand
+ARG CODE_DIR /srv/broadway-on-demand
+
 # Change to dependency directory
+
+RUN echo $DEP_DIR
+RUN echo $CODE_DIR
+
 WORKDIR ${DEP_DIR}
 RUN apk add --no-cache gcc musl-dev linux-headers
 COPY requirements.txt requirements.txt
-RUN python3 -m virtualenv ./env && source ./env/bin/activate
-RUN pip install -r requirements.txt
-ENV PATH=${DEP_DIR}/env/bin
+RUN python3 -m venv ./env
+RUN source ./env/bin/activate && pip install -r requirements.txt
 
 # Change to the code directory for development
 WORKDIR ${CODE_DIR}
@@ -15,4 +21,5 @@ ENV FLASK_APP=src
 ENV FLASK_ENV=development
 ENV FLASK_RUN_HOST=0.0.0.0
 ENV FLASK_DEBUG="true"
-CMD ["${DEP_DIR}/env/bin/flask", "run"]
+ENV PATH=${DEP_DIR}/env/bin
+CMD flask run

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ urllib3==1.24.2
 werkzeug==0.15.5
 ansi2html==1.5.2
 gunicorn==20.0.4
-google-auth==2.3.3
+identity==0.3.2

--- a/sample_config.py
+++ b/sample_config.py
@@ -31,20 +31,12 @@ BROADWAY_API_URL = "http://some-broadway-api-server.example/api/v1"
 # API token used to authenticate /system/ routes.
 SYSTEM_API_TOKEN = "some_token"
 
-# GitHub Enterprise OAuth client ID and secret.
-GHE_CLIENT_ID = "some_client_id"
-GHE_CLIENT_SECRET = "some_client_secret"
-# GitHub Enterprise OAuth base URL.
-GHE_OAUTH_URL = "https://some-github-enterprise-server.example/login/oauth"
-# GitHub Enterprise OAuth scopes to request from users (comma-separated string, no spaces).
-GHE_OAUTH_SCOPES = "none"
-GHE_LOGIN_URL = "%s/authorize?client_id=%s&scope=%s" % (GHE_OAUTH_URL, GHE_CLIENT_ID, GHE_OAUTH_SCOPES)
-
-# GitHub Enterprise API base URL.
+# GitHub API base URL.
 GHE_API_URL = "https://api.github.com"
 
-# Google client ID for authentication (include the .apps.googleusercontent.com)
-GOOGLE_CLIENT_ID = "some_client_id.apps.googleusercontent.com"
-
-# Restricts Google Auth logins to emails with the given domain
-GOOGLE_AUTH_DOMAIN = "illinois.edu"
+# Microsoft Azure auth config
+AUTH_DOMAIN = "some auth domain like `example.edu`"
+MIP_SCOPES = ["email"]
+MIP_AUTHORITY = "some authority or `https://login.microsoftonline.com/common` for multi-tenant world-wide cloud"
+MIP_CLIENT_ID = "some_client_id"
+MIP_CLIENT_SECRET = "some_client_secret"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -4,6 +4,7 @@ from werkzeug.urls import url_parse
 from http import HTTPStatus
 from google.oauth2 import id_token
 from google.auth.transport import requests
+from pymongo import MongoClient
 
 from config import *
 from src import db, bw_api, auth, ghe_api, util, common
@@ -17,6 +18,7 @@ from src.util import generate_csrf_token
 
 app = Flask(__name__)
 app.config["SESSION_TYPE"] = SESSION_TYPE
+app.config["SESSION_MONGODB"] = MongoClient(host=SESSION_MONGODB)
 app.config["SESSION_MONGODB_DB"] = SESSION_MONGODB_DB
 app.config["MONGO_URI"] = MONGO_URI
 app.jinja_env.globals['csrf_token'] = generate_csrf_token

--- a/src/auth.py
+++ b/src/auth.py
@@ -1,15 +1,24 @@
 from functools import wraps
 from http import HTTPStatus
 
-from flask import session, redirect, url_for, abort, request
+from flask import session, redirect, url_for, abort, request, render_template, make_response
 from src import db
 from src.common import verify_staff, verify_admin
 
-from config import SYSTEM_API_TOKEN
+import identity.web
+
+from config import SYSTEM_API_TOKEN, MIP_AUTHORITY, MIP_CLIENT_ID, MIP_CLIENT_SECRET, MIP_SCOPES, AUTH_DOMAIN
 
 UID_KEY = "netid"
 CID_KEY = "cid"
+LOGIN_ERR_KEY = "login_error"
 
+mip_auth = identity.web.Auth(
+    session=session,
+    authority=MIP_AUTHORITY,
+    client_id=MIP_CLIENT_ID,
+    client_credential=MIP_CLIENT_SECRET,
+)
 
 def get_netid():
 	"""
@@ -64,17 +73,15 @@ def require_system_auth(func):
 
 def require_token_auth(func):
 	"""
-	A route decorator check user's username and Authorization token for login. 
+	A route decorator check user's course token for login. 
 	This is useful for api calls to this site. A session is not created for such access.
 	"""
 	@wraps(func)
 	def wrapper(*arg, **kwargs):
-		netid = request.form["netid"]
 		token = request.headers["Authorization"]
-		user = db.get_user(netid)
-		if user is None or user["personal_token"] != token:
+		course = kwargs[CID_KEY]
+		if course is None or course.get("github_token", None) != token:
 			return abort(HTTPStatus.FORBIDDEN)
-		kwargs[UID_KEY] = netid
 		return func(*arg, **kwargs)
 	return wrapper
 
@@ -95,21 +102,71 @@ def require_admin_status(func):
 		return func(*args, **kwargs)
 	return wrapper
 
+def begin_login():
+	"""
+	Render the login page for the user using external IAM service
+	"""
+	# Have to save error in cookie so error is saved across multiple redirects so user is
+	# logged out of Microsoft before coming back to the login page if login fails
+	error = request.cookies.get(LOGIN_ERR_KEY, "")
+
+	resp = make_response(render_template("login.html", error=error, success=request.args.get("success", "0"), **mip_auth.log_in(
+        scopes=MIP_SCOPES, # Have user consent to scopes during log-in
+		redirect_uri=(url_for(".login_callback", _external=True)),
+        prompt="login",  # Optional. More values defined in  https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+    )))
+
+	# Reset cookie to empty string
+	resp.set_cookie(LOGIN_ERR_KEY, "")
+
+	return resp
+
+
+def complete_login():
+    result = mip_auth.complete_log_in(request.args)
+    if "error" in result:
+        return render_template("login.html", error=result.get("error_description", ""))
+
+    try:
+        email = result["email"]
+    except ValueError:
+        error = "Could not find email associated with account. Please contact course staff."
+        return logout(error)
+
+    if not email.endswith(AUTH_DOMAIN):
+        error = f"Account email does not belong to domain \"{AUTH_DOMAIN}\". Please contact course staff."
+        return logout(error)
+
+    netid = email[:email.rfind('@')]
+    set_uid(netid)
+    return redirect(url_for(".root"))
+
 
 def set_uid(uid):
 	"""
-	Save the current user's NetID with their session.
+	Save the current user's NetID with their session, effectively logging them in.
 	:param uid: a NetID.
 	"""
 	session[UID_KEY] = uid
 
 
-def logout():
+def logout(error=""):
 	"""
 	Remove the current user's NetID from their session, effectively logging them out. Redirects the user to the login
 	page.
+	:param error: any error from previous login attempt
 	:return: a redirect response to the login page.
 	"""
 	if UID_KEY in session:
 		del session[UID_KEY]
-	return redirect(url_for(".login_page"))
+
+
+	success = "1" if error == "" else "0"
+	# Use the following to log user out of SSO and Broadway On-Demand
+	# resp = make_response(redirect(mip_auth.log_out(url_for(".login_page", success=success, _external=True))))
+
+	mip_auth.log_out("")
+	resp = make_response(redirect(url_for(".login_page", success=success)))
+	resp.set_cookie(LOGIN_ERR_KEY, error)
+
+	return resp

--- a/src/auth.py
+++ b/src/auth.py
@@ -2,7 +2,6 @@ from functools import wraps
 from http import HTTPStatus
 
 from flask import session, redirect, url_for, abort, request, render_template, make_response
-from src import db
 from src.common import verify_staff, verify_admin
 
 import identity.web

--- a/src/db.py
+++ b/src/db.py
@@ -40,15 +40,6 @@ def get_user(netid):
 	return mongo.db.users.find_one({"_id": netid})
 
 
-def set_user_access_token(netid, access_token):
-	"""
-	Updates the access token for the user with the given NetID, or adds a new user with the given NetID and access token
-	if the NetID does not exist.
-	:param netid: a user's NetID.
-	:param access_token: a GitHub Enterprise access token for the user.
-	"""
-	mongo.db.users.update_one({"_id": netid}, {"$set": {"access_token": access_token}}, upsert=True)
-
 def get_courses_for_student_or_staff(netid):
 	student_course = get_courses_for_student(netid)
 	staff_course = get_courses_for_staff(netid)

--- a/src/ghe_api.py
+++ b/src/ghe_api.py
@@ -4,27 +4,12 @@ from http import HTTPStatus
 from datetime import datetime as dt
 
 from config import (
-	GHE_OAUTH_URL, GHE_API_URL, GHE_CLIENT_ID, GHE_CLIENT_SECRET, DEV_MODE, TZ
+	GHE_API_URL, DEV_MODE, TZ
 )
 
 logger = logging.getLogger(__name__)
 
 ACCEPT_JSON = {"Accept": "application/json"}
-
-
-def get_access_token(code):
-	data = {
-		"client_id": GHE_CLIENT_ID,
-		"client_secret": GHE_CLIENT_SECRET,
-		"code": code
-	}
-	try:
-		resp = requests.post("%s/access_token" % GHE_OAUTH_URL, json=data, headers=ACCEPT_JSON)
-		return resp.json()["access_token"]
-	except requests.exceptions.RequestException:
-		return None
-	except KeyError:
-		return None
 
 
 def get_login(access_token):

--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -15,8 +15,6 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
             integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
             crossorigin="anonymous"></script>
-    <script src="https://apis.google.com/js/platform.js?onload=onGoogleAPILoad" async defer></script>
-    <meta name="google-signin-client_id" content="{{google_client_id}}">
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <link href="{{ url_for('.static_file', path='styles.css', v='7') }}" rel="stylesheet">
 
@@ -70,25 +68,3 @@
         {% endif %}
     </div>
 </nav>
-<script>
-    function onGoogleAPILoad() {
-        gapi.load('auth2', function() {
-            gapi.auth2.init({ hosted_domain: '{{google_auth_domain}}' });
-        });
-    }
-
-    const logoutButton = document.getElementById('logout-button');
-    logoutButton.addEventListener('click', (e) => {
-        // check if user is signed in to Google, and log them out of Google first (before redirect to /logout)
-        if (gapi.auth2) {
-            const authInstance = gapi.auth2.getAuthInstance();
-            if (authInstance) {
-                // make sure we finish signing out of Google before redirecting to logout page
-                e.preventDefault();
-                authInstance.signOut().then(() => {
-                    location.assign(logoutButton.href);
-                });
-            }
-        }
-    });
-</script>

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -14,18 +14,12 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
             integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy"
             crossorigin="anonymous"></script>
-    <script src="https://accounts.google.com/gsi/client?onload=onGoogleAPILoad" async defer></script>
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <link href="{{ url_for('.static_file', path='styles.css') }}" rel="stylesheet">
 
     <title>Log In | Broadway On Demand</title>
 </head>
 <body class="h-100">
-    <div id="g_id_onload"
-        data-client_id="{{google_client_id}}"
-        data-ux_mode="popup"
-	data-callback="onSignIn">
-    </div>
     <div class="h-100 d-flex flex-column">
         <nav class="navbar bg-dark">
             <a class="navbar-brand">Broadway On Demand</a>
@@ -37,13 +31,9 @@
                         <div class="card-body">
                             <h4 class="card-title" style="margin-bottom: 0.5em;">Authentication Required</h4>
                             <div>
-                                <p>Make sure your Illinois Google account is enabled <a target="_blank" href="https://cloud-dashboard.illinois.edu/">here</a> before trying to sign in</p>
-				<!-- <button id="google-signin-button" type="button" class="btn btn-primary m-1" disabled>Loading...</button> -->
-				<div class="g_id_signin" data-type="standard"></div>
-                                <br>
-<!--                                 <a href="{{login_url}}">
-                                    <button type="submit" class="btn btn-primary m-1">Log in with GitHub Enterprise</button>
-                                </a> -->
+                                <a href="{{auth_uri}}">
+                                    <button type="submit" class="btn btn-primary m-1">Log in</button>
+                                </a>
                                 {% if config.ENV == "development" %}
                                     <form action="{{ url_for('.login_as', path=url_for('.root')) }}" method="POST">
                                         <div class="d-flex align-items-center mt-2">
@@ -54,26 +44,21 @@
                                     </form>
                                 {% endif %}
                             </div>
+                            {% if error != "" %}
+                            <div class="mt-3 alert alert-danger" role="alert">
+                              {{ error }}
+                            </div>
+                            {% endif %}
+                            {% if success != "0" %}
+                            <div class="mt-3 alert alert-success" role="alert">
+                                Successfully logged out
+                            </div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-    <script>
-        function onSignIn(auth_data) {
-            const id_token = auth_data.credential
-            const google_auth_url = "{{ url_for('.login_google_auth') }}"
-            fetch(google_auth_url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify({ id_token })
-            })
-                .then(res => res.text())
-                .then(redirectUri => location.assign(redirectUri))
-        }
-    </script>
 </body>
 </html>


### PR DESCRIPTION
This PR integrates Azure authentication using the [identity](https://pypi.org/project/identity/) Python library as outlined in the [MSAL docs](https://msal-python.readthedocs.io/en/latest/#). The changes this PR introduces are:

- Remove GHE and Google Auth callbacks as well as Google Auth Javascript in the layout and login html files
- Remove functionality for retrieving GHE auth token and storing this in the database, as this is not used anymore
- Instead of authenticating session-less API requests with the stored GHE auth token, use the course auth token which is already used to retrieve commit information for the student from the Github API
- Add a `dev` directory with Docker containers and a compose file for local development
- Fix a bug wherein changing the host for MongoDB session storage in the config did not work

(closes #154)